### PR TITLE
Menu placement improvements

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -514,17 +514,38 @@ removeContent ^ <Alien[Element]> = (
 	^visual removeChild: (visual at: 'lastChild')
 )
 toggleContent = (
-	menuActive ifTrue: [removeContent] ifFalse: [updateContent].
-	menuActive:: menuActive not.
+    (shell toggleActiveMenu: visual) 
+        ifTrue: [updateContent.]
 )
 updateContent ^ <Alien[Element]> = (
-	| menuContent <Alien[Div]> |
-	menuContent:: computeContentForMenu: menuSupplier.
-	(menuContent at: 'style') 
-	   at: alignment put: 0;
-	   at: 'display' put: 'block'.
-	visual appendChild: menuContent.
-	^menuContent
+    | menu x left maxLeft menuWidth rightInset |
+    
+    (* TODO: We the populated menu dimensions *)
+    menuWidth:: 180.
+    rightInset: 20.
+
+    menu:: computeContentForMenu: menuSupplier.
+    x:: visual at: 'offsetLeft'.
+
+    (* Determine optimal placement *)
+    maxLeft:: window at: 'innerWidth'.
+    maxLeft:: maxLeft - menuWidth - rightInset.
+    x > maxLeft 
+        ifTrue: [ left:: maxLeft asString ]
+        ifFalse: [ left:: x asString ].
+
+    (menu at: 'style') 
+        at: alignment put: 0;
+        at: 'position' put: 'absolute';
+        at: 'left' put: left,'px';
+        at: 'width' put: menuWidth asString,'px';
+        at: 'display' put: 'block'.
+    visual appendChild: menu.
+
+    shell activeMenu: menu.
+    shell activeMenuParent: visual.
+
+    ^menu.
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
   ^visual (* optimize later? Does it even matter? *)
@@ -990,6 +1011,8 @@ class HopscotchShell = (
 	currentPresenterX
         toolbarHolder = document createElement: 'div'.
 	contentHolder = document createElement: 'div'.
+    public activeMenu <Alien[Div]> ::= nil.
+    public activeMenuParent <Alien[Node]> ::= nil.
 	|
 	windowList add: self.
 ) (
@@ -1102,6 +1125,22 @@ public displayPresenter: p = (
 public registerNewPresenter: newPresenter <Presenter> = (
   assert: [newPresenter creatingWindow isNil or: [newPresenter creatingWindow = self]] message: 'Error: Attempt to register presenter from another window'.
   navigator registerNewPresenter: newPresenter
+)
+public closeActiveMenu = (
+    activeMenu isNil
+    ifFalse: [
+        | parent <Alien[Node]> = activeMenu at: 'parentNode'. |
+        parent removeChild: activeMenu.
+        activeMenu: nil.]
+)
+public toggleActiveMenu: aVisual ^ <Boolean> = (
+    | activeChanged ::= true. |
+    activeMenu isNil ifFalse: [
+        | menuParent <Alien[Node]> = activeMenu at: 'parentNode'. |
+        shell activeMenuParent = aVisual 
+            ifTrue: [activeChanged:: false].
+        shell closeActiveMenu].
+    ^activeChanged
 )
 ) : (
 )


### PR DESCRIPTION
Menus are now placed at point of origin. 
Basic extents checking is done to keep menu from going out of bound to the right.
Menu width is hardcoded. Width can be calculated once I figure out how to get widest measure string.
Menu does not dismiss when click occurs outside of bounds.

I am mainly looking for idiomatic newspeak coding advice.