### PR TITLE
Measure menu item text to calculate width

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -107,33 +107,33 @@ Further documentation of subjects and decorators will be added in the future.
     public useSurroundingNavigation <Boolean> ::= true.
     
 (* Images *)
-	public accept16px = images accept16px.
-      public backImage = images backImage.
-      public backDownImage = images backDownImage.		
-     	public backOutImage = images backOutImage.
-     	public backOverImage = images backOverImage.
-	public cancel16px = images cancel16px.
-	public disclosureClosedImage = images disclosureClosedImage.
-	public disclosureOpenImage = images disclosureOpenImage.	
-	public disclosureTransitionImage = images disclosureTransitionImage.
-	public dropDownImage = images dropDownImage.
-	public dropDownOutImage = images dropDownOutImage.
-	public dropDownOverImage = images dropDownOverImage.
-      public forwardImage = images forwardImage.
-      public forwardDownImage = images forwardDownImage.		
-     	public forwardOutImage = images forwardOutImage.
-     	public forwardOverImage = images forwardOverImage.
-	public historyImage = images historyImage.
-   	public historyDownImage = images historyDownImage.	
-   	public historyOverImage = images historyOverImage.
-      public homeImage = images homeImage.
-      public homeDownImage = images homeDownImage.		
-     	public homeOutImage = images homeOutImage.
-     	public homeOverImage = images homeOverImage.	
-	public refreshImage = images refreshImage.
-   	public refreshDownImage = images refreshDownImage.	
-   	public refreshOverImage = images refreshOverImage.
-    	public refreshOutImage = images refreshOutImage.	
+    public accept16px = images accept16px.
+    public backImage = images backImage.
+    public backDownImage = images backDownImage.		
+    public backOutImage = images backOutImage.
+    public backOverImage = images backOverImage.
+    public cancel16px = images cancel16px.
+    public disclosureClosedImage = images disclosureClosedImage.
+    public disclosureOpenImage = images disclosureOpenImage.	
+    public disclosureTransitionImage = images disclosureTransitionImage.
+    public dropDownImage = images dropDownImage.
+    public dropDownOutImage = images dropDownOutImage.
+    public dropDownOverImage = images dropDownOverImage.
+    public forwardImage = images forwardImage.
+    public forwardDownImage = images forwardDownImage.		
+    public forwardOutImage = images forwardOutImage.
+    public forwardOverImage = images forwardOverImage.
+    public historyImage = images historyImage.
+    public historyDownImage = images historyDownImage.	
+    public historyOverImage = images historyOverImage.
+    public homeImage = images homeImage.
+    public homeDownImage = images homeDownImage.		
+    public homeOutImage = images homeOutImage.
+    public homeOverImage = images homeOverImage.	
+    public refreshImage = images refreshImage.
+    public refreshDownImage = images refreshDownImage.	
+    public refreshOverImage = images refreshOverImage.
+    public refreshOutImage = images refreshOutImage.	
 	|) (
 class BlankFragment = LeafFragment (
 ) (
@@ -518,17 +518,26 @@ toggleContent = (
 )
 calculateMenuWidth^<Float> = (
     | 
-    characterWidth <Float> = 12. (* Guessing for now. Need font metrics class *)
+    canvas <Alien> = document createElement: 'canvas'.
+    edgePad <Float> = 45. (* menu item left pad + right pad + magic *) 
     currentWidth <Float> ::= 0.
-    maxWidth <Float> ::= 100. 
+    maxWidth <Float> ::= 0. 
+    context <Context>
+    textMetrics <Alien>
+    textWidth <Float>
     | 
+
+    context:: (canvas getContext: '2d').
+    context at: 'font' put: '14px sans-serif'.
+
     menuSupplier value do: 
         [:menuItem <MenuItem | Symbol> | 
-            currentWidth:: (menuItem first size) * characterWidth.
+            textMetrics:: context measureText: menuItem first.            
+            currentWidth:: textMetrics at: 'width'.            
             currentWidth > maxWidth
-                ifTrue: [ maxWidth:: currentWidth.].
+                ifTrue: [maxWidth:: currentWidth.].
         ].
-    ^maxWidth.
+    ^maxWidth + edgePad.
 )
 updateContent ^ <Alien[Element]> = (
     | 
@@ -536,8 +545,10 @@ updateContent ^ <Alien[Element]> = (
     menuWidth <Float> = calculateMenuWidth.
     rightInset <Float> = 20.
     x <Float> = visual at: 'offsetLeft'.
+    y <Float> = visual at: 'offsetTop'.
     left <Float>
     maxLeft <Float>
+    top <Float>
     |
 
     (* Determine optimal placement *)
@@ -546,10 +557,15 @@ updateContent ^ <Alien[Element]> = (
         ifTrue: [ left:: maxLeft asString ]
         ifFalse: [ left:: x asString ].
 
+    y < 0 
+        ifTrue: [ top:: 0 ]
+        ifFalse: [ top:: y asString ].
+
     (menu at: 'style') 
         at: 'outline' put: 0;
         at: 'position' put: 'absolute';
         at: 'left' put: left,'px';
+        at: 'top' put: top,'px';
         at: 'width' put: menuWidth asString,'px';
         at: 'cursor' put: 'default';        
         at: 'display' put: 'block'.


### PR DESCRIPTION
Measure menu items text to calculate ideal width.
(What if there are no menu items?  I guess the width is zero!)

Pin vertical position of menu to within window visible bounds.

Fix weird tabs. (My editor did it. I can reverts, but they were weird.)

This measuring and theming will eventually bubble out to a theming system. I am still learning the system.