### PR TITLE
Set search input text to min and max widths

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -291,14 +291,17 @@ createVisual = (
 		at: 'resize' put: true.
 	frame appendChild: textArea.
 	options:: JSObject new.
-	options at: 'lineWrapping' put: true.
+	options at: 'lineWrapping' put: false.
 	options at: 'readOnly' put: readOnly.
+    options at: 'scrollbarStyle' put: 'null'.
 	editor:: CodeMirror fromTextArea: textArea with: options.
-      registerChangeHandler.
+    registerChangeHandler.
 	((textArea at: 'nextSibling') at: 'style') 
-		at: 'height' put: 'unset';
-		at: 'width' put: '100%';
-		at: 'fontFamily' put: 'TimesNewRoman';
+		at: 'min-width' put: '25vw';
+        at: 'max-width' put: '80vw';
+		at: 'height' put: '24px';
+        at: 'wrap' put: 'soft';
+		at: 'font-family' put: 'sans-serif';
 		at: 'borderStyle' put: 'solid';
 		at: 'borderWidth' put: '1px';
 		at: 'borderColor' put: 'gray'.


### PR DESCRIPTION
Configure search field to look and behave in a more normal fashion.
Set a default height so height does not increase when first character is entered.
Set min and max width based on percentage of window.
Disable wrapping and scrollbar so input works more like standard search and URL bars.
Set system font.