### PR TITLE
Unify context menu call paths

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -157,7 +157,9 @@ deployAsWebPage = (
 )
 testActions = (
 	subject isTestConfiguration ifFalse: [^nothing].
-	^row: {link: '[run tests]' action: [enterSubject:: subject testingSubject]. link: '[show tests]' action: [enterSubject:: subject inactiveTestingSubject]}.
+	^row: {
+		link: '[run tests]' action: [enterSubject:: subject testingSubject]. 
+		link: '[show tests]' action: [enterSubject:: subject inactiveTestingSubject]}.
 )
 respondToRunApp: paused = (
 	(* bogus: The subject might not be in the root namespace. *)

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -2893,14 +2893,9 @@ positionMenu: menu <Alien[Div]> forShell: s <HopscotchShell> = (
 
 	(* Determine optimal placement *)
     maxLeft:: (window at: 'innerWidth') - w - rightInset.
-    x > maxLeft 
-        ifTrue: [ left:: maxLeft asString ]
-        ifFalse: [ left:: x asString ].
-
-    y < 0 
-        ifTrue: [ top:: 0 ]
-        ifFalse: [ top:: y asString ].
-
+	maxLeft out.
+	left:: x < maxLeft ifTrue: maxLeft ifFalse:x
+	top:: y < 0 ifTrue: [0] ifFalse:[y]
     (menu at: 'style') 
         at: 'position' put: 'absolute';
         at: 'left' put: left,'px';

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -498,7 +498,7 @@ Class methods that provide convenient defaults for the button images and the ali
 ) (
 createVisual ^ <Alien[Element]> = (
 	| column = super createVisual. |
-	column addEventListener: 'click' action: [:event | toggleContent. nil].
+	column addEventListener: 'click' action: [:event | updateContent. nil].
 	(column at: 'style')
 		at: 'cursor' put: 'pointer'.
 	^column
@@ -512,75 +512,9 @@ isMyKind: f <Fragment> ^ <Boolean> = (
 removeContent ^ <Alien[Element]> = (
 	^visual removeChild: (visual at: 'lastChild')
 )
-toggleContent = (
-    (shell toggleActiveMenu: visual) 
-        ifTrue: [updateContent.]
-)
-calculateMenuWidth^<Float> = (
-    | 
-    canvas <Alien> = document createElement: 'canvas'.
-    edgePad <Float> = 45. (* menu item left pad + right pad + magic *) 
-    currentWidth <Float> ::= 0.
-    maxWidth <Float> ::= 0. 
-    context <Context>
-    textMetrics <Alien>
-    textWidth <Float>
-    | 
-
-    context:: (canvas getContext: '2d').
-    context at: 'font' put: '14px sans-serif'.
-
-    menuSupplier value do: 
-        [:menuItem <MenuItem | Symbol> | 
-            textMetrics:: context measureText: menuItem first.            
-            currentWidth:: textMetrics at: 'width'.            
-            currentWidth > maxWidth
-                ifTrue: [maxWidth:: currentWidth.].
-        ].
-    ^maxWidth + edgePad.
-)
 updateContent ^ <Alien[Element]> = (
-    | 
-    menu <Alien[Div]> = computeContentForMenu: menuSupplier.
-    menuWidth <Float> = calculateMenuWidth.
-    rightInset <Float> = 20.
-    x <Float> = visual at: 'offsetLeft'.
-    y <Float> = visual at: 'offsetTop'.
-    left <Float>
-    maxLeft <Float>
-    top <Float>
-    |
-
-    (* Determine optimal placement *)
-    maxLeft:: (window at: 'innerWidth') - menuWidth - rightInset.
-    x > maxLeft 
-        ifTrue: [ left:: maxLeft asString ]
-        ifFalse: [ left:: x asString ].
-
-    y < 0 
-        ifTrue: [ top:: 0 ]
-        ifFalse: [ top:: y asString ].
-
-    (menu at: 'style') 
-        at: 'outline' put: 0;
-        at: 'position' put: 'absolute';
-        at: 'left' put: left,'px';
-        at: 'top' put: top,'px';
-        at: 'width' put: menuWidth asString,'px';
-        at: 'cursor' put: 'default';        
-        at: 'display' put: 'block'.
-    
-    menu at: 'id' put: 'DropDownMenuFragment'.
-    menu at: 'tabIndex' put: 0.
-
-    visual appendChild: menu.
-
-    menu focus.
-    menu at: 'onblur' put: [:event | shell closeActiveMenu. nil].
-
-    shell activeMenu: menu.
-    shell activeMenuParent: visual.
-    
+    | menu <Alien[Div]> = computeContentForMenu: menuSupplier. |
+	showMenu: menu forShell: shell inVisual: visual.
     ^menu.
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
@@ -1173,15 +1107,6 @@ public displayPresenter: p = (
 public registerNewPresenter: newPresenter <Presenter> = (
   assert: [newPresenter creatingWindow isNil or: [newPresenter creatingWindow = self]] message: 'Error: Attempt to register presenter from another window'.
   navigator registerNewPresenter: newPresenter
-)
-public toggleActiveMenu: aVisual ^ <Boolean> = (
-    | activeChanged ::= true. |
-    activeMenu isNil ifFalse: [
-        | menuParent <Alien[Node]> = activeMenu at: 'parentNode'. |
-        shell activeMenuParent = aVisual 
-            ifTrue: [activeChanged:: false].
-        shell closeActiveMenu].
-    ^activeChanged
 )
 public closeActiveMenu = (
     activeMenu isNil
@@ -1897,15 +1822,8 @@ nothing = (
 noticeSubstanceCreation = (
 	(* Received after the #definition method of the receiver has been invoked and the result remembered as its substance. The substance hasn't been asked to create a visual yet. *)
 )
-openMenu: aMenu <Menu> ^ <Alien[Div]> = (
-	| menuContent <Alien[Div]> |
-	menuContent:: computeContentForMenu: [aMenu].
-	(menuContent at: 'style') at: 'display' put: 'block'.
-	visual appendChild: menuContent.
-	menuContent addEventListener: 'click' action:
-		[:event | visual removeChild: menuContent. nil].
-	^menuContent
-(* so the issue here is to actually open a menu that was not in the tree before? And how to close it*)
+openMenu: aMenu <Menu> = (	
+	showMenu: (computeContentForMenu: [aMenu]) forShell: shell inVisual: visual.
 )
 openMenuWithLabelsAndActions: labelsAndActions = (
 	openMenu: (menuWithLabelsAndActions: labelsAndActions)
@@ -2932,7 +2850,7 @@ public Window ^ <HopscotchWindow class> = (
   ^useSurroundingNavigation ifTrue: [HopscotchWindow] ifFalse: [EmbeddedHopscotchWindow]
 )
 computeContentForMenu: menuSupplier <[Menu]> ^ <Alien[Div]> = (
-    | dropDownContent = document createElement: 'div'. |
+    |  dropDownContent = document createElement: 'div'. |
     (dropDownContent at: 'style')
         at: 'color' put: 'black';
         at: 'backgroundColor' put: '#F6F6F6';
@@ -2943,13 +2861,54 @@ computeContentForMenu: menuSupplier <[Menu]> ^ <Alien[Div]> = (
         at: 'border' put: '#C7C7C7 solid 1px';
         at: 'border-radius' put: '5px';
         at: 'box-shadow' put: '0px 0px 15px darkgrey';
-		at: 'display' put: 'none'.
+		at: 'display' put: 'block';
+        at: 'outline' put: 0;
+        at: 'cursor' put: 'default'.
+
 	menuSupplier value do: 
 		[:menuItem <MenuItem | Symbol> |
 		 | itemContent <Alien[Element]> |
 		 itemContent:: contentFor: menuItem within: dropDownContent.
 		 dropDownContent appendChild: itemContent].
+
 	^dropDownContent
+)
+positionMenu: menu <Alien[Div]> forShell: s <HopscotchShell> = (
+	|
+    edgePad <Float> = 55.
+	rightInset <Float> = 20.
+    x <Float> = menu at: 'offsetLeft'.
+    y <Float> = menu at: 'offsetTop'.
+	w <Float>
+    left <Float>
+    maxLeft <Float>
+    top <Float>
+	|
+
+	(* Pad the width for menu insets. Annoying. *)
+	w:: menu at: 'offsetWidth'.
+	(* Can't add this value above because it is a string until assignment? *)
+	w:: w + edgePad.
+	menu at: 'width' put: w.
+
+	(* Determine optimal placement *)
+    maxLeft:: (window at: 'innerWidth') - w - rightInset.
+    x > maxLeft 
+        ifTrue: [ left:: maxLeft asString ]
+        ifFalse: [ left:: x asString ].
+
+    y < 0 
+        ifTrue: [ top:: 0 ]
+        ifFalse: [ top:: y asString ].
+
+    (menu at: 'style') 
+        at: 'position' put: 'absolute';
+        at: 'left' put: left,'px';
+        at: 'top' put: top,'px';
+        at: 'width' put: w asString,'px'.
+    
+    menu at: 'tabIndex' put: 0.
+    menu at: 'onblur' put: [:event | s closeActiveMenu. nil].
 )
 contentFor: menuItem < MenuItem | Symbol> within: dropDownContent ^ <Alien[Element]> = (
 	| entry |
@@ -2973,6 +2932,15 @@ contentFor: menuItem < MenuItem | Symbol> within: dropDownContent ^ <Alien[Eleme
 		addEventListener: 'click' action:
 			[:event | menuItem last value. nil].
 	^entry
+)
+showMenu: menu <Menu> 
+		forShell: s <HopscotchShell> 
+		inVisual: v <Visual> = (
+    v appendChild: menu.
+	positionMenu: menu forShell: s.
+	menu focus.
+    s activeMenu: menu.
+    s activeMenuParent: v.
 )
 ) : (
 )

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -2893,13 +2893,12 @@ positionMenu: menu <Alien[Div]> forShell: s <HopscotchShell> = (
 
 	(* Determine optimal placement *)
     maxLeft:: (window at: 'innerWidth') - w - rightInset.
-	maxLeft out.
-	left:: x < maxLeft ifTrue: maxLeft ifFalse:x
-	top:: y < 0 ifTrue: [0] ifFalse:[y]
+	left:: x > maxLeft ifTrue: [maxLeft] ifFalse: [x].
+	top:: y < 0 ifTrue: [0] ifFalse:[y].
     (menu at: 'style') 
         at: 'position' put: 'absolute';
-        at: 'left' put: left,'px';
-        at: 'top' put: top,'px';
+        at: 'left' put: left asString,'px';
+        at: 'top' put: top asString,'px';
         at: 'width' put: w asString,'px'.
     
     menu at: 'tabIndex' put: 0.


### PR DESCRIPTION
I found another code path that opens a menu (deploy, configurations) so I have merged the code paths. There is some slinging of shell and visuals as parameters probably because I still am figuring out Window, HopscotchWindow, HopscothShell. etc.

Menu sizing still needs work.