### PR TITLE
Add slot visibility icons; add additional theme text size placeholder constants

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -348,9 +348,15 @@ slotList ^ <Fragment> = (
 		   ifTrue: [
 			column: {
 				label: 'Slots' weight: #bold.
+				smallBlank.
 				row: {
-					mediumBlank.
-					column: (sl collect: [:ea | label: ea name]).
+					(* Class visibility icons need to be placed here *)					
+					column: (sl collect: [:ea | 
+						row: {
+							image: (iconForAccessModifier: ea accessModifier). 
+							label: ea name.
+						}
+						]).
 				}
 			}.
 		] ifFalse: [nothing].

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -124,7 +124,9 @@ Further documentation of subjects and decorators will be added in the future.
 	public styleFontColor = 'black'.
 	public styleFontFamilyMonospace = 'ui-monospace, monospace'.
 	public styleFontFamilySerif = 'serif'.
-	public styleFontSizeEditor = '14px'.
+	public styleFontSizeEditor = '16px'.
+	public styleFontSizeMenu = '14px'.	
+	public styleFontSizeText = '16px'.
 	public styleFontSizeSearch = '24px'.
 	public styleRowHeight = '30px'.
 	public styleZebraPrimaryColor = Color white.
@@ -2047,7 +2049,7 @@ createVisual ^ <Alien[HTMLElement]> = (
 	| visual |
 	visual:: super createVisual.
 	(visual at: 'style')
-		at: 'font-size' put: styleFontSizeEditor.
+		at: 'font-size' put: styleFontSizeText.
 	^visual
 )
 ) : (
@@ -2084,7 +2086,7 @@ createVisual ^ <Alien[HTMLElement]> = (
 		at: 'align-content' put: alignItems;
 		at: 'justify-content' put: justifyContent;
 		at: 'font-family' put: 'serif';
-		at: 'font-size' put: styleFontSizeEditor.
+		at: 'font-size' put: styleFontSizeText.
 	nil = color ifFalse:
 		[color applyToStyle: (container at: 'style')].
 	definitions do: [:fragment <Fragment> |
@@ -3003,7 +3005,7 @@ contentFor: menuItem < MenuItem | Symbol> within: dropDownContent ^ <Alien[Eleme
    (entry at: 'style')
         at: 'color' put: '#3C3C3C';
         at: 'font-family' put: 'sans-serif';
-        at: 'font-size' put: styleFontSizeEditor;
+        at: 'font-size' put: styleFontSizeMenu;
         at: 'padding-left' put: '20px';
         at: 'padding-right' put: '20px';
         at: 'height' put: '28px';


### PR DESCRIPTION
Slot visibility icons are back.
Specialize text sizes a bit more in advance of theming.

Spacing is still not great because of png files. I think it might be time to create a Shape class that uses SVG internally. Maybe there is alreaady one! Time to go spelunking.