### PR TITLE
Menu fixes

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -322,7 +322,7 @@ headerDefinition ^ <Fragment> = (
 			ifTrue: [nestingInformationLine]
 			ifFalse: [nothing].
 	filler.
-	itemReferencesMenuButtonWithAction: [goToMessages].
+	dropDownMenu: [messagesMenu].
     smallBlank.
 	dropDownMenu: [methodMenuFor: subject name]
    }.
@@ -1495,7 +1495,7 @@ colorizeMethodSource: s <String> withEditor: cm <CodeMirrorFragment> = (
 public expand = (
 	^substance expand
 )
-goToMessages = (
+messagesMenu = (
 	| messagesAndActions messageItems classItems |
 	messagesAndActions:: List new.
 	messagesAndActions add:
@@ -1505,7 +1505,7 @@ goToMessages = (
 		[messagesAndActions
 			add: #separator;
 			addAll: messageItems].
-	openMenuWithLabelsAndActions: messagesAndActions
+	^menuWithLabelsAndActions: messagesAndActions
 )
 public isKindOfMethodPresenter ^ <Boolean> = (
   ^true
@@ -1595,7 +1595,7 @@ public definition ^ <Fragment> = (
 			(link: subject name action: [toggle expand]) color: actionLinkColor.
 		      nestingInfo.
 	            filler.
-	            itemReferencesMenuButtonWithAction: [goToMessages].
+	            dropDownMenu: [messagesMenu].
 	            smallBlank.
 	            dropDownMenu: [methodMenuFor: subject name]
 			}
@@ -1612,7 +1612,7 @@ public definition ^ <Fragment> = (
 			  (link: subject name action: [toggle collapse]) color: actionLinkColor.
 				nestingInfo.
 				filler.
-				itemReferencesMenuButtonWithAction: [goToMessages].
+				itemReferencesMenuButtonWithAction: [messagesMenu].
 				smallBlank.
 				dropDownMenu: [methodMenuFor: subject name]
 			}.

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -322,7 +322,7 @@ headerDefinition ^ <Fragment> = (
 			ifTrue: [nestingInformationLine]
 			ifFalse: [nothing].
 	filler.
-	dropDownMenu: [messagesMenu].
+	dropDownMenu: [messagesMenu] image: ide images itemReferencesImage.
     smallBlank.
 	dropDownMenu: [methodMenuFor: subject name]
    }.
@@ -612,9 +612,9 @@ classNameAndHierarchySummary = (
 			filler.
             (ClassActionsPresenter onSubject: subject) elasticity: 1.
 			smallBlank.
-			itemReferencesMenuButtonWithAction: [browseSelector: subject name].
+			itemReferencesButtonWithAction: [browseSelector: subject name].
 			smallBlank.
-			saveMenuButtonWithAction: [respondToSave].
+			saveButtonWithAction: [respondToSave].
 			smallBlank.
 			refreshButton.			
 			smallBlank.
@@ -1595,7 +1595,7 @@ public definition ^ <Fragment> = (
 			(link: subject name action: [toggle expand]) color: actionLinkColor.
 		      nestingInfo.
 	            filler.
-	            dropDownMenu: [messagesMenu].
+	            dropDownMenu: [messagesMenu] image: ide images itemReferencesImage.
 	            smallBlank.
 	            dropDownMenu: [methodMenuFor: subject name]
 			}
@@ -1612,7 +1612,7 @@ public definition ^ <Fragment> = (
 			  (link: subject name action: [toggle collapse]) color: actionLinkColor.
 				nestingInfo.
 				filler.
-				itemReferencesMenuButtonWithAction: [messagesMenu].
+				dropDownMenu: [messagesMenu] image: ide images itemReferencesImage.
 				smallBlank.
 				dropDownMenu: [methodMenuFor: subject name]
 			}.
@@ -2497,11 +2497,7 @@ itemReferencesButtonWithAction: aBlock = (
 	^imageButton: {ide images itemReferencesImage}
 	action: aBlock
 )
-itemReferencesMenuButtonWithAction: aBlock = (
-	^imageButton: {ide images itemReferencesImage}
-	action: aBlock
-)
-saveMenuButtonWithAction: aBlock = (
+saveButtonWithAction: aBlock = (
 	^imageButton: {ide images downloadImage}
 	action: aBlock
 )

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -2930,6 +2930,9 @@ positionMenu: menu <Alien[Div]> forShell: s <HopscotchShell> = (
     top <Float>
 	|
 
+    x out.
+    y out.
+    
 	(* Pad the width for menu insets. Annoying. *)
 	w:: menu at: 'offsetWidth'.
 	(* Can't add this value above because it is a string until assignment? *)

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -1708,6 +1708,9 @@ public definition ^<Fragment> = (
 dropDownMenu: menu <[Menu]> ^ <DropDownMenuFragment> = (
 	^DropDownMenuFragment menu: menu
 )
+dropDownMenu: menu <[Menu]> image: im <Image> ^ <DropDownMenuFragment> = (
+	^DropDownMenuFragment menu: menu images: { im }
+)
 dropDownMenu: menu <[Menu]> alignment: side <Symbol> ^ <DropDownMenuFragment> = (
 	^DropDownMenuFragment menu: menu alignment: side
 )
@@ -2918,21 +2921,17 @@ computeContentForMenu: menuSupplier <[Menu]> ^ <Alien[Div]> = (
 
 	^dropDownContent
 )
-positionMenu: menu <Alien[Div]> forShell: s <HopscotchShell> = (
+positionMenu: menu <Alien[Div]> at: y <Float> forShell: s <HopscotchShell> = (
 	|
     edgePad <Float> = 55.
 	rightInset <Float> = 20.
     x <Float> = menu at: 'offsetLeft'.
-    y <Float> = menu at: 'offsetTop'.
 	w <Float>
     left <Float>
     maxLeft <Float>
     top <Float>
 	|
 
-    x out.
-    y out.
-    
 	(* Pad the width for menu insets. Annoying. *)
 	w:: menu at: 'offsetWidth'.
 	(* Can't add this value above because it is a string until assignment? *)
@@ -2979,7 +2978,7 @@ showMenu: menu <Menu>
 		forShell: s <HopscotchShell> 
 		inVisual: v <Visual> = (
     v appendChild: menu.
-	positionMenu: menu forShell: s.
+	positionMenu: menu at: (v at: 'offsetTop') forShell: s.
 	menu focus.
     s activeMenu: menu.
     s activeMenuParent: v.


### PR DESCRIPTION
Fix the item reference menu position by generalizing the drop down menu code.
Improve the vertical placement of the menu so top is under the mouse as is the norm.

I haven't seen the text wrapping bug. I wonder if some bugs passed in the night? Could you flush your cache, zap your PRAM, reinstall Windows and let me know if you still see that glitch?

