### PR TITLE
Improve text editor accept/cancel controls

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -259,46 +259,71 @@ applyStyles = (
      editor refresh.
    ]
 )
-controlBarColor = (
-	^Color r: 0.95 g: 0.792 b: 0.475
-)
+
 createVisual = (
 	| 
-    frame  <Alien[Div]> 
-    accept  <Alien[Img]> 
-    cancel <Alien[Img]> 
-    textArea 
-    <Alien[Span]> 
-    options <Alien[JSObject]> 
+	container <Alien[Div]> 
+	frame <Alien[Div]> 
+	accept <Alien[Img]> 
+	cancel <Alien[Img]> 
+	textArea <Alien[Span]> 
+	options <Alien[JSObject]> 
     |
-	frame:: document createElement: 'div'.
-    frame at: 'id' put: 'CodeMirrorFragment'.
-	(frame at: 'style')
+
+	container:: document createElement: 'div'.
+	container at: 'id' put: 'CodeMirrorContainer'.
+	(container at: 'style')
 		at: 'display' put: 'flex';
-		at: 'opacity' put: 1.
-	counterfactualBar:: document createElement: 'span'.
+		at: 'flex-direction' put: 'column';
+		at: 'width' put: '99%';
+		at: 'background-color' put: 'white';
+		at: 'opacity' put: 1;
+		at: 'borderStyle' put: 'solid';
+		at: 'borderWidth' put: '1px';
+		at: 'borderColor' put: 'gray'.
+
+	counterfactualBar:: document createElement: 'div'.
 	(counterfactualBar at: 'style')
-		at: 'backgroundColor' put: controlBarColor asCSSString;
-		at: 'flex' put: 'none'.
+		at: 'display' put: 'flex';
+		at: 'flex-direction' put: 'row';
+		at: 'align-items' put: 'center';
+		at: 'justify-content' put: 'flex-end';
+		at: 'opacity' put: '0.0';
+		at: 'z-index' put: '10';
+		at: 'width' put: '100%'.
+
 	accept:: document createElement: 'img'.
 	accept at: 'src' put: (accept16px yourself at: 'src').
 	(accept at: 'style') 
 		at: 'width' put: '22px'.
 	accept at: 'onclick' put:
 		[:event | respondToAccept: event. nil].
+	counterfactualBar appendChild: accept.
+
 	cancel:: document createElement: 'img'.
 	cancel at: 'src' put: (cancel16px yourself at: 'src').
 	(cancel at: 'style') 
 		at: 'width' put: '22px'.
 	cancel at: 'onclick' put:
 		[:event | respondToCancel. nil].
-	counterfactualBar appendChild: accept.
 	counterfactualBar appendChild: cancel.
+
+	container appendChild: counterfactualBar.
+
+	frame:: document createElement: 'div'.
+	frame at: 'id' put: 'CodeMirrorFragment'.
+	(frame at: 'style')
+		at: 'display' put: 'flex';
+		at: 'flex-direction' put: 'row';
+		at: 'margin-top' put: '-15px'.
+	container appendChild: frame.
+
 	textArea:: document createElement: 'textarea'.
 	textArea
 		at: 'value' put:  textSlot;
 		at: 'resize' put: true.
 	frame appendChild: textArea.
+
 	options:: JSObject new.
 	options at: 'lineWrapping' put: true.
 	options at: 'readOnly' put: readOnly.
@@ -307,13 +332,12 @@ createVisual = (
     registerChangeHandler.
 	((textArea at: 'nextSibling') at: 'style') 
 		at: 'height' put: 'unset';
-		at: 'width' put: '100%';
+		at: 'width' put: '100%';	
+		at: 'background-color' put: 'transparent';
 		at: 'fontFamily' put: styleFontFamilySerif;
-		at: 'font-size' put: styleFontSizeEditor;
-		at: 'borderStyle' put: 'solid';
-		at: 'borderWidth' put: '1px';
-		at: 'borderColor' put: 'gray'.
-	^frame
+		at: 'font-size' put: styleFontSizeEditor.
+
+	^container
 )
 public defaultAcceptResponse = (
 	textSlot:: editor getValue.
@@ -337,8 +361,11 @@ defaultStyle ^ <Alien[Object]> = (
 public enterEditState = (
 	lastChangeWasSynthetic ifTrue: [lastChangeWasSynthetic:: false. ^self].
 	isInEditState ifFalse:
-		[visual appendChild: counterfactualBar.
-		isInEditState:: true].
+		[	
+		(counterfactualBar at: 'style')
+			at: 'opacity' put: '1.0'.
+		isInEditState:: true
+		].
 )
 public isKindOfCodeMirrorFragment ^ <Boolean> = (
 	^true
@@ -413,7 +440,8 @@ updateVisualsFromSameKind: oldFragment <CodeMirrorFragment>  ^ <Alien[CodeMIrror
 public leaveEditState = (
 	isInEditState ifTrue:
 		[
-        (counterfactualBar at: #parentNode) isNil ifFalse: [visual removeChild: counterfactualBar].
+		(counterfactualBar at: 'style')
+			at: 'opacity' put: '0.0'.
 		isInEditState:: false.
 		(*removeMessages*)]
 )
@@ -1157,7 +1185,7 @@ historyButton ^ <ButtonFragment> = (
       action: [showHistory].
 )
 toolbarItems ^ <Array[Fragment]>  = (
- ^{filler. historyButton. mediumBlank. homeButton. blank: 5. refreshButton. blank: 5}
+ ^{filler. historyButton. smallBlank. homeButton. smallBlank. refreshButton. smallBlank}
 )
 refreshButton ^ <ButtonFragment> = (
 ^imageButton: {


### PR DESCRIPTION
The way the counterfactual bar is added and removed from the right side of the editor can be distracting.
This change places the controls at the top right of the editor. They appear based on the modified state of the code. The controls could fade in and out to make their appearance even less jarring.

This isn't a big issue and you may like the current behavior of the counterfactual base better. Now that I am using the editor more and more, I am tackling my perceived friction points.

![Screen Shot 2020-12-09 at 2 28 34 PM](https://user-images.githubusercontent.com/65915337/101694037-bd602200-3a2f-11eb-9ac5-39346fee7753.png)
