### PR TITLE
Counterfactual fixes

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -288,14 +288,16 @@ createVisual = (
 		at: 'flex-direction' put: 'row';
 		at: 'align-items' put: 'center';
 		at: 'justify-content' put: 'flex-end';
-		at: 'opacity' put: '0.0';
 		at: 'z-index' put: '10';
-		at: 'width' put: '100%'.
+		at: 'opacity' put: '0.0';
+        at: 'width' put: 'auto';
+        at: 'pointer-events' put: 'none'.
 
 	accept:: document createElement: 'img'.
 	accept at: 'src' put: (accept16px yourself at: 'src').
 	(accept at: 'style') 
-		at: 'width' put: '22px'.
+		at: 'width' put: '22px';
+        at: 'pointer-events' put: 'auto'.
 	accept at: 'onclick' put:
 		[:event | respondToAccept: event. nil].
 	counterfactualBar appendChild: accept.
@@ -303,7 +305,8 @@ createVisual = (
 	cancel:: document createElement: 'img'.
 	cancel at: 'src' put: (cancel16px yourself at: 'src').
 	(cancel at: 'style') 
-		at: 'width' put: '22px'.
+		at: 'width' put: '22px';
+        at: 'pointer-events' put: 'auto'.
 	cancel at: 'onclick' put:
 		[:event | respondToCancel. nil].
 	counterfactualBar appendChild: cancel.
@@ -315,7 +318,7 @@ createVisual = (
 	(frame at: 'style')
 		at: 'display' put: 'flex';
 		at: 'flex-direction' put: 'row';
-		at: 'margin-top' put: '-15px'.
+		at: 'margin-top' put: '-20px'.
 	container appendChild: frame.
 
 	textArea:: document createElement: 'textarea'.


### PR DESCRIPTION
Overlap counterfactual and text editor to eliminate excess padding.
Pass mouse events through to editor.