### PR TITLE
Add message bar to bottom of code editor

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -233,6 +233,7 @@ public class CodeMirrorFragment onText: t <String> = LeafFragment (
     public editor <Alien[CodeMirror]>
 	textSlot <TextFragment | String> ::= t.
 	public counterfactualBar <Alien[Span]>
+	public messageContainer <Alien[Span]>
 	public isInEditState ::= false.
 	public changeResponse <[TextEditorFragment]>
 	public acceptResponse <[TextEditorFragment]>
@@ -276,10 +277,10 @@ createVisual = (
 		at: 'flex-direction' put: 'column';
 		at: 'width' put: '99%';
 		at: 'background-color' put: 'white';
-		at: 'opacity' put: 1;
+		at: 'opacity' put: 1.0;
 		at: 'borderStyle' put: 'solid';
 		at: 'borderWidth' put: '1px';
-		at: 'borderColor' put: 'gray'.
+		at: 'borderColor' put: 'silver'.
 
 	counterfactualBar:: document createElement: 'div'.
 	(counterfactualBar at: 'style')
@@ -309,7 +310,6 @@ createVisual = (
 	cancel at: 'onclick' put:
 		[:event | respondToCancel. nil].
 	counterfactualBar appendChild: cancel.
-
 	container appendChild: counterfactualBar.
 
 	frame:: document createElement: 'div'.
@@ -338,6 +338,20 @@ createVisual = (
 		at: 'background-color' put: 'transparent';
 		at: 'fontFamily' put: styleFontFamilySerif;
 		at: 'font-size' put: styleFontSizeEditor.
+
+	messageContainer:: document createElement: 'div'.
+	(messageContainer at: 'style')
+		at: 'opacity' put: 0.0;
+		at: 'background-color' put: '#FFE6B3';
+		at: 'border-top' put: '1px solid silver';
+		at: 'display' put: 'flex';
+		at: 'flex-direction' put: 'row';
+		at: 'align-items' put: 'left';
+		at: 'vertical-align' put: 'middle';
+		at: 'padding-left' put: '10px';
+        at: 'width' put: '100%';
+		at: 'height' put: '20px'.
+	container appendChild: messageContainer.
 
 	^container
 )
@@ -397,7 +411,12 @@ respondToChange: event <Alien[Event]> = (
 		ifFalse: [changeResponse cull: self cull: event]
 )
 public showMessage: message <String> = (
-	message out.
+	messageContainer at: 'innerHTML' put: message.
+	(messageContainer at: 'style') at: 'opacity' put: 1.0.
+)
+public removeMessages = (
+	messageContainer at: 'innerHTML' put: ''.
+	(messageContainer at: 'style') at: 'opacity' put: 0.0.
 )
 public style: style <Alien[JSObject]> from: start <Integer> to: end <Integer>  = (
 	styles add: {start. end. style}.
@@ -422,21 +441,19 @@ updateVisualsFromSameKind: oldFragment <CodeMirrorFragment>  ^ <Alien[CodeMIrror
 		editor setValue: textSlot.
 		oldFragment leaveEditState.
 		].
+
 	counterfactualBar:: oldFragment counterfactualBar.
 	(counterfactualBar at: 'firstChild') at: 'onclick' put:
 		[:event | respondToAccept: event. nil].
 	(counterfactualBar at: 'lastChild') at: 'onclick' put:
 		[:event | respondToCancel. nil].
-      changeHandler callback:  [:codeMirror :change | respondToChange: codeMirror. nil].
+	
+	messageContainer:: oldFragment messageContainer.
+
+	changeHandler callback: [:codeMirror :change | respondToChange: codeMirror. nil].
+
+
 	^oldFragment visual
-)
-public leaveEditState = (
-	isInEditState ifTrue:
-		[
-		(counterfactualBar at: 'style')
-			at: 'opacity' put: '0.0'.
-		isInEditState:: false.
-		(*removeMessages*)]
 )
 public enterEditState = (
 	lastChangeWasSynthetic ifTrue: [lastChangeWasSynthetic:: false. ^self].
@@ -447,6 +464,14 @@ public enterEditState = (
 			at: 'opacity' put: '1.0'.
 		isInEditState:: true
 		].
+)
+public leaveEditState = (
+	isInEditState ifTrue:
+		[
+		(counterfactualBar at: 'style')
+			at: 'opacity' put: '0.0'.
+		isInEditState:: false.
+		removeMessages]
 )
 ) : (
 )
@@ -2554,9 +2579,8 @@ setText: t <TextFragment | String> = (
 setVisualText: aText = (
 	hasVisual ifTrue: [setText: aText]
 )
-public showMessage: m = (
-#BOGUS.
-	m out
+public showMessage: message = (
+	window alert: message
 )
 public text = (
 	^textX


### PR DESCRIPTION
This widget works much  like the Squeak version.

The easiest way to see it is to just add a class with the default name twice.

I do see some exciting messages now.  When I try to rename a class by opening the "new" method and chaning the class name to one that conficts, I see "Exception`3303782372887767407:" when hitting the accept icon button.