### PR TITLE
Add change label to history

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -470,6 +470,9 @@ createVisual = (
 
 	^container
 )
+public hasPendingChanges ^<Boolean> = (
+    ^isInEditState
+)
 ) : (
 )
 class ColorDecorator color: c <Color> = Decorator (
@@ -782,6 +785,11 @@ public decorate: aVisual = (
 public elasticity: x = (
 	expansibility: x.
 	compressibility: x.
+)
+public hasPendingChanges ^<Boolean> = (
+    (* Answer whether the fragment at this time displays any changes made by the user which haven't yet been applied to the displayed objects (for example, method edits). *)
+    childrenDo: [:any | any hasPendingChanges ifTrue: [^true]].
+    ^false
 )
 public hasVisual = (
 	^visualX isNil not
@@ -1364,6 +1372,10 @@ class LeafFragment = Fragment () (
 public childrenDo: aBlock = (
 	(* No children. *)
 )
+public hasPendingChanges ^<Boolean> = (
+    (* For simplicity, we assume that most leaf fragments can never have pending changes. Those for which it is not true should override this method. *)
+    ^false
+)
 ) : (
 )
 class MultiPageNavigationHistory = NavigationHistory (
@@ -1907,13 +1919,16 @@ linkImage: image action: block = (
 )
 public listElementMetapresenter ^<Presenter> = (
 (* A presenter that can represent the receiver in a list of presenters such as the History. *)
-
-	^row: {
-		minimalMetapresenter.
-		mediumBlank.
-		filler compressibility: 0.
-		(deferred: [extraInformationMetapresenter]) compressibility: 1.
-	}
+    ^row: {
+        minimalMetapresenter.
+        mediumBlank.        
+        deferred:
+            [hasPendingChanges
+                ifTrue: [label: 'has unsaved edits' weight: #bold.]
+                ifFalse: [nothing]].
+        filler compressibility: 0.
+        (deferred: [extraInformationMetapresenter]) compressibility: 1.
+    }
 )
 mediumBlank = (
 	^blank: 10
@@ -2540,6 +2555,9 @@ defaultChangeResponse = (
 public enterEditState = (
 	isInEditState ifFalse:
 		[isInEditState:: true].
+)
+public hasPendingChanges ^<Boolean> = (
+    ^isInEditState
 )
 public isKindOfTextEditorFragment ^ <Boolean> = (
 	^true


### PR DESCRIPTION
Append "has unsaved edits" to label in history view to indicated dirty state of file.