### PR TITLE
Fix toolbar buttons, UI clean up

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -1949,7 +1949,7 @@ public tag ^ <String> = (
   ^title
 )
 public title = (
-  ^subject key weight: #bold
+  ^subject key (*asText allBold*)
 )
 respondToCompileFiles = (
    multipleFileChooser chooseFileList: [:fl | 

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -1949,7 +1949,7 @@ public tag ^ <String> = (
   ^title
 )
 public title = (
-  ^subject key (*asText allBold*)
+  ^subject key weight: #bold
 )
 respondToCompileFiles = (
    multipleFileChooser chooseFileList: [:fl | 

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -1371,9 +1371,9 @@ createVisual ^ <Visual> = (
 		at: 'width' put: widthStyle;
 		at: 'height' put: heightStyle.
 
+    img at: 'onclick' put: [:event | action value. false].
+
     img
-        addEventListener: 'onclick' action:
-            [:event | action value. nil];
         addEventListener: 'mousedown' action:
 		    [:event | (img at: 'style') at: 'filter' put: 'brightness(120%)'. nil];
         addEventListener: 'mouseover' action:

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -1216,7 +1216,10 @@ public class HopscotchWindow into: container openSubject: s = HopscotchShell (
 class ToolbarPresenter = Presenter onSubject: nil (
 ) (
 definition ^ <Fragment> = (
- ^row: toolbarItems
+    ^column: {
+        row: toolbarItems.
+        smallBlank.
+    }
 )
 historyButton ^ <ButtonFragment> = (
   ^imageButton: historyImage action: [showHistory] size: styleButtonSize

--- a/WorkspaceManager.ns
+++ b/WorkspaceManager.ns
@@ -59,7 +59,7 @@ definition = (
 	^column: {
 		minorHeadingBlock: (
 			row: {
-				label: 'Workspaces' (*asText allBold*).
+				label: 'Workspaces' weight: #bold.
 				addButtonWithAction: [updateGUI: [respondToAddWorkspace]].
 				filler.
 				expandButtonWithAction: [toggles childrenDo: [:each <ToggleComposer> | each expand]].


### PR DESCRIPTION
I am not sure why setting the dict value instead of using addEventListener works, but I'll revert to the previous code.

Add some space between bottom of toolbar and content area.

Enable bolding of Workspaces title.