### PR TITLE
Don't clip slot column

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -366,15 +366,14 @@ slotList ^ <Fragment> = (
 				label: 'Slots' weight: #bold.
 				smallBlank.
 				row: {
-					(* Class visibility icons need to be placed here *)					
-					column: (sl collect: [:ea | 
+					(column: (sl collect: [:ea | 
 						row: {
                             defaultBlank.
 							image: (iconForAccessModifier: ea accessModifier) size: styleButtonSize. 
                             defaultBlank.
 							label: ea name.
 						}
-						]).
+					])) elasticity: 1.
 				}
 			}.
 		] ifFalse: [nothing].


### PR DESCRIPTION
Set elasticity so column will expand to show slot names.

Remove comment about class visibility icon. I added them a few PRs ago.