### PR TITLE
On-demand evaluation invoked by keyboard

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -1023,6 +1023,10 @@ class EvaluationPresenter onSubject: s <EvaluationViewState> = ProgrammingPresen
 changeResponse = (
   ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
 )
+evaluateResponse ^ <[:CodeMirrorFragment]> = (
+    'evaluateRespons 2' out.
+	^[:ed <CodeMirrorFragment> | ]
+)
 clearResultsButton ^ <Fragment> = (
   ^button: 'Clear Results' action: [updateGUI: [subject clear]]
 )
@@ -1037,7 +1041,6 @@ definition = (
 	^column: {
 	      row: {
 	         button: 'Evaluate Selection' action: [updateGUI: [subject evaluate: (withoutNbsp: cm editor getSelection)]].
-	         invertEvalStatusButton.
 	         clearResultsButton
 	      }.
 		editorDefinition.
@@ -1047,14 +1050,11 @@ definition = (
 editorDefinition ^ <CodeMirrorFragment> = (
 	| initialSource |
 	initialSource:: ''.
-	cm:: (codeMirror: initialSource) changeResponse: changeResponse.
+	cm:: (codeMirror: initialSource) 
+        changeResponse: changeResponse;
+        evaluateResponse: evaluateResponse.
 	(* ide colorizer colorizeDoIt: initialSource fromClass: nil via: (colorizingBlockFor: cm).*)
 	^cm
-)
-invertEvalStatusButton ^ <ButtonFragment> = (
-  ^subject isLive ifTrue: [
-	 button: 'Suspend Live Evaluation' action: [updateGUI: [subject isLive: false]]
-	 ] ifFalse: [ button: 'Start Live Evaluation' action: [updateGUI: [subject isLive: true]]]
 )
 public isKindOfEvaluationPresenter ^ <Boolean> = (
   ^true
@@ -1128,7 +1128,7 @@ public class EvaluationViewState onModel: m <ObjectMirror | ActivationMirror> = 
   public mirror <ObjectMirror | ActivationMirror> = m. 
   results_slot <List[ThreadMirror]> ::= List new. 
   lastEvalWasLive <Boolean> ::= false. 
-  public isLive <Boolean> ::= true.
+  public isLive <Boolean> ::= false.
   |
 ) (
 public clear = (
@@ -2755,11 +2755,12 @@ public class EvaluatorPresenter onSubject: s <ObjectSubject | ActivationSubject>
 | cm <CodeMirrorFragment> |
 ) (
 deadChangeResponse = (
-  ^[:editor <CodeMirrorFragment>  | | src <String> =  editor textBeingAccepted. |
-	ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
-	editor isInEditState: true.
-	editor editor focus.
-   ].
+    ^[:editor <CodeMirrorFragment>  | 
+        | src <String> =  editor textBeingAccepted. |
+        ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
+        editor isInEditState: true.
+        editor editor focus.
+    ].
 )
 linkForCompileError: error <Exception> = (
 	^column: {
@@ -2818,6 +2819,9 @@ definition = (
 changeResponse = (
   ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
 )
+evaluateResponse ^ <[:CodeMirrorFragment]> = (
+	^[:ed <CodeMirrorFragment> | ]
+)
 clearResultsButton ^ <Fragment> = (
   ^button: 'Clear Results' action: [updateGUI: [subject clear]]
 )
@@ -2838,22 +2842,18 @@ definitionForEvaluator = (
 	^column: {
 	      row: {
 	         button: 'Evaluate Selection' action: [updateGUI: [subject evaluate: (withoutNbsp: cm editor getSelection)]].
-	         invertEvalStatusButton.
 	         clearResultsButton
 	      }.
 		editorDefinition.
 		column: results.
 	}
 )
-invertEvalStatusButton ^ <ButtonFragment> = (
-  ^subject isLive ifTrue: [
-	 button: 'Suspend Live Evaluation' action: [updateGUI: [subject  isLive: false]]
-	 ] ifFalse: [ button: 'Start Live Evaluation' action: [updateGUI: [subject isLive: true]]]
-)
 editorDefinition ^ <CodeMirrorFragment> = (
 	| initialSource |
 	initialSource:: subject initialSource.
-	cm:: (codeMirror: initialSource) changeResponse: changeResponse.
+	cm:: (codeMirror: initialSource) 
+        changeResponse: changeResponse;
+        evaluateResponse: evaluateResponse.
 
 	(* ide colorizer colorizeDoIt: initialSource fromClass: nil via: (colorizingBlockFor: cm).*)
 	^cm

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -1024,23 +1024,33 @@ changeResponse = (
   ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
 )
 evaluateResponse ^ <[:CodeMirrorFragment]> = (
-    'evaluateRespons 2' out.
-	^[:ed <CodeMirrorFragment> | ]
+    ^[:editor <CodeMirrorFragment>  | 
+        | src <String> ::=  cm editor getSelection. |
+        src isEmpty ifTrue: [
+            src:: cm editor getValue.
+        ].
+        src isEmpty ifFalse: [
+            updateGUI: [ 
+                subject evaluate: (withoutNbsp: src).                 
+            ].
+            editor editor focus.
+        ].
+    ].
 )
 clearResultsButton ^ <Fragment> = (
   ^button: 'Clear Results' action: [updateGUI: [subject clear]]
 )
 deadChangeResponse = (
-  ^[:editor <CodeMirrorFragment>  | | src <String> =  editor textBeingAccepted. |  	
-	ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
-	editor isInEditState: true.
-	editor editor focus.
-   ].
+    ^[:editor <CodeMirrorFragment>  | 
+        | src <String> =  editor textBeingAccepted. |  	
+	    ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
+	    editor isInEditState: true.
+	    editor editor focus.
+    ].
 )
 definition = (
 	^column: {
 	      row: {
-	         button: 'Evaluate Selection' action: [updateGUI: [subject evaluate: (withoutNbsp: cm editor getSelection)]].
 	         clearResultsButton
 	      }.
 		editorDefinition.
@@ -1107,7 +1117,11 @@ liveChangeResponse = (
    ].
 )
 results ^ <List[Fragment]> = (
-  ^subject results collect: [:r | r isKindOfThreadMirror ifTrue: [linkForThread: r] ifFalse: [linkForCompileError: r]]
+    ^subject results collect: [
+        :r | r isKindOfThreadMirror 
+            ifTrue: [linkForThread: r] 
+            ifFalse: [linkForCompileError: r]
+        ]
 )
 withoutNbsp: string = (
 	('a' at: 1) isKindOfInteger
@@ -2820,13 +2834,28 @@ changeResponse = (
   ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
 )
 evaluateResponse ^ <[:CodeMirrorFragment]> = (
-	^[:ed <CodeMirrorFragment> | ]
+    ^[:editor <CodeMirrorFragment>  | 
+        | src <String> ::=  cm editor getSelection. |
+        src isEmpty ifTrue: [
+            src:: cm editor getValue.
+        ].
+        src isEmpty ifFalse: [
+            updateGUI: [ 
+                subject evaluate: (withoutNbsp: src).                 
+            ].
+            editor editor focus.
+        ].
+    ].
 )
 clearResultsButton ^ <Fragment> = (
   ^button: 'Clear Results' action: [updateGUI: [subject clear]]
 )
 results ^ <List[Fragment]> = (
-  ^subject results collect: [:r | r isKindOfThreadMirror ifTrue: [linkForThread: r] ifFalse: [linkForCompileError: r]]
+    ^subject results collect: [:r | 
+        r isKindOfThreadMirror 
+            ifTrue: [linkForThread: r] 
+            ifFalse: [linkForCompileError: r]
+        ]
 )
 liveChangeResponse = (
   ^[:editor <CodeMirrorFragment>  | | src <String> =  editor textBeingAccepted. |
@@ -2834,14 +2863,13 @@ liveChangeResponse = (
 		subject evaluateLive: (withoutNbsp: src).
 		ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
 		editor isInEditState: true.
-		].
+    ].
 	editor editor focus.
    ].
 )
 definitionForEvaluator = (
 	^column: {
 	      row: {
-	         button: 'Evaluate Selection' action: [updateGUI: [subject evaluate: (withoutNbsp: cm editor getSelection)]].
 	         clearResultsButton
 	      }.
 		editorDefinition.

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -1017,125 +1017,6 @@ row1: row1 row2: row2 = (
 )
 ) : (
 )
-class EvaluationPresenter onSubject: s <EvaluationViewState> = ProgrammingPresenter onSubject: s (
-| cm <CodeMirrorFragment> |
-) (
-changeResponse = (
-  ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
-)
-evaluateResponse ^ <[:CodeMirrorFragment]> = (
-    ^[:editor <CodeMirrorFragment>  | 
-        | src <String> ::=  cm editor getSelection. |
-        src isEmpty ifTrue: [
-            src:: cm editor getValue.
-        ].
-        src isEmpty ifFalse: [
-            updateGUI: [ 
-                subject evaluate: (withoutNbsp: src).                 
-            ].
-            editor editor focus.
-        ].
-    ].
-)
-clearResultsButton ^ <Fragment> = (
-  ^button: 'Clear Results' action: [updateGUI: [subject clear]]
-)
-deadChangeResponse = (
-    ^[:editor <CodeMirrorFragment>  | 
-        | src <String> =  editor textBeingAccepted. |  	
-	    ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
-	    editor isInEditState: true.
-	    editor editor focus.
-    ].
-)
-definition = (
-	^column: {
-	      row: {
-	         clearResultsButton
-	      }.
-		editorDefinition.
-		column: results.
-	}
-)
-editorDefinition ^ <CodeMirrorFragment> = (
-	| initialSource |
-	initialSource:: ''.
-	cm:: (codeMirror: initialSource) 
-        changeResponse: changeResponse;
-        evaluateResponse: evaluateResponse.
-	(* ide colorizer colorizeDoIt: initialSource fromClass: nil via: (colorizingBlockFor: cm).*)
-	^cm
-)
-public isKindOfEvaluationPresenter ^ <Boolean> = (
-  ^true
-)
-isMyKind: f <Fragment> ^ <Boolean> = (
-  ^f isKindOfEvaluationPresenter
-)
-linkForCompileError: error <Exception> = (
-	^column: {
-		smallBlank.
-		(link: error printString action:
-			[inspectObjectMirror: (ObjectMirror reflecting: error)])
-				color: (Color r: 1 g: 0 b: 0).
-	}
-)
-linkForError: thread <ThreadMirror> = (
-	^column: {
-		smallBlank.
-		(link: thread result reflectee printString action:
-			[enterSubject:: ide debugging ThreadSubject onModel: thread])
-				color: (Color r: 1 g: 0 b: 0).
-	}
-)
-linkForEvaluation: r ^ <Fragment> = (
-  r isKindOfError ifTrue: [:e | ^linkForCompileError: e].
-  r isFulfilled ifTrue: [^linkForResult: r].
-  r isBroken ifTrue: [^linkForError: r]. 
- 'result is neither error nor fulfilled nor broken!' out.
-)
-linkForResult: r ^ <Fragment> = (
-	^column: {
-		smallBlank.
-		(link: r result reflectee printString action:
-			[enterSubject:: ObjectSubject onModel: r result]).
-	}
-)
-linkForThread: thread <ThreadMirror> ^ <Fragment> = (
-	thread isFulfilled ifTrue: [^linkForResult: thread].
-	thread isBroken ifTrue: [^linkForError: thread].
-	^nothing
-)
-liveChangeResponse = (
-  ^[:editor <CodeMirrorFragment>  | | src <String> =  editor textBeingAccepted. |
-	updateGUI: [		
-		subject evaluateLive: (withoutNbsp: src).
-		ide colorizer colorizeDoIt: src fromClass: nil via: (colorizingBlockFor: editor).
-		editor isInEditState: true.
-		].
-	editor editor focus.
-   ].
-)
-results ^ <List[Fragment]> = (
-    ^subject results collect: [
-        :r | r isKindOfThreadMirror 
-            ifTrue: [linkForThread: r] 
-            ifFalse: [linkForCompileError: r]
-        ]
-)
-withoutNbsp: string = (
-	('a' at: 1) isKindOfInteger
-		ifTrue:
-			[ | bytes = ByteArray withAll: string. |
-			1 to: bytes size do: [:index | (bytes at: index) = 160 ifTrue: [bytes at: index put: 32]].
-			^bytes asString]
-		ifFalse:
-			[ | nonbreakingSpace = String fromRune: 160.
-			space = String fromRune: 32. |
-			^string replaceAll: nonbreakingSpace with: space]
-)
-) : (
-)
 public class EvaluationViewState onModel: m <ObjectMirror | ActivationMirror> = (
 (* An evaluator maintains a list of results of prior evaluations. *)
   | 
@@ -2778,7 +2659,6 @@ deadChangeResponse = (
 )
 linkForCompileError: error <Exception> = (
 	^column: {
-		smallBlank.
 		(link: error printString action:
 			[inspectObjectMirror: (ObjectMirror reflecting: error)])
 				color: (Color r: 1 g: 0 b: 0).
@@ -2786,7 +2666,6 @@ linkForCompileError: error <Exception> = (
 )
 linkForError: thread <ThreadMirror> = (
 	^column: {
-		smallBlank.
 		(link: thread result reflectee printString action:
 			[enterSubject:: ide debugging ThreadSubject onModel: thread])
 				color: (Color r: 1 g: 0 b: 0).
@@ -2800,7 +2679,6 @@ linkForEvaluation: r ^ <Fragment> = (
 )
 linkForResult: r ^ <Fragment> = (
 	^column: {
-		smallBlank.
 		(link: r result reflectee printString action:
 			[enterSubject:: ObjectSubject onModel: r result]).
 	}
@@ -2848,7 +2726,9 @@ evaluateResponse ^ <[:CodeMirrorFragment]> = (
     ].
 )
 clearResultsButton ^ <Fragment> = (
-  ^button: 'Clear Results' action: [updateGUI: [subject clear]]
+    ^imageButton: ide images clearImage 
+            action: [updateGUI: [subject clear]] 
+            size: styleButtonSize
 )
 results ^ <List[Fragment]> = (
     ^subject results collect: [:r | 
@@ -2868,12 +2748,15 @@ liveChangeResponse = (
    ].
 )
 definitionForEvaluator = (
+    | items <List[Fragment]> = results. |
 	^column: {
-	      row: {
-	         clearResultsButton
-	      }.
 		editorDefinition.
-		column: results.
+        row: {
+            (column: items) elasticity: 1.
+            items isEmpty
+                ifTrue: [smallBlank]
+                ifFalse: [clearResultsButton].
+        }.		
 	}
 )
 editorDefinition ^ <CodeMirrorFragment> = (

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -251,6 +251,7 @@ public class CodeMirrorFragment onText: t <String> = LeafFragment (
 	public changeResponse <[TextEditorFragment]>
 	public acceptResponse <[TextEditorFragment]>
 	public cancelResponse <[TextEditorFragment]>
+    public evaluateResponse <[TextEditorFragment]>
 	styles ::= List new.
 	public beforeChangeHandler <CallBackWrapper>
 	public changeHandler <CallBackWrapper>
@@ -333,6 +334,10 @@ respondToCancel = (
 			ifTrue: [defaultCancelResponse]
 			ifFalse: [cancelResponse cull: self](*]*)
 )
+respondToEvaluate = (
+    nil = evaluateResponse 
+        ifFalse: [evaluateResponse cull: self]
+)
 respondToBeforeChange: event <Alien[Event]> = (	
 	updateEditState
 )
@@ -345,6 +350,7 @@ respondToKeyPress: event <Alien[Event]> = (
 	| 
 	key <Character> = (event at: 'key'). 
 	metaPressed <Boolean> = (event at: 'metaKey').
+    shiftPressed <Boolean> = (event at: 'shiftKey').
 	|
 
 	(isInEditState and: [useEditControls]) ifTrue: [
@@ -353,15 +359,26 @@ respondToKeyPress: event <Alien[Event]> = (
 				ifTrue: [ 			
 					lastChangeWasSynthetic:: true.	
 					respondToAccept: event.
+                    ^self.
 				].
 			
 			key = 'Escape'
 				ifTrue: [
 					lastChangeWasSynthetic:: true.
 					respondToCancel.
+                    ^self.
 				].		
 		].
-	]
+	].
+
+    shiftPressed ifTrue: [
+        key = 'Enter'
+            ifTrue: [ 		
+                event preventDefault.
+                respondToEvaluate.
+                ^self.
+            ].
+    ].
 )
 public style: style <Alien[JSObject]> from: start <Integer> to: end <Integer>  = (
 	styles add: {start. end. style}.
@@ -2638,8 +2655,8 @@ the cursor position based on that. But so far that hasn't worked. And we have is
 	^newString size
 )
 registerChangeHandler = (
-      changeHandler:: CallBackWrapper wrapping: [:codeMirror :change | respondToChange: codeMirror. nil].
-      editor on: 'change' respondToChange: changeHandler wrappedCallback.
+    changeHandler:: CallBackWrapper wrapping: [:codeMirror :change | respondToChange: codeMirror. nil].
+    editor on: 'change' respondToChange: changeHandler wrappedCallback.
 )
 public defaultAcceptResponse = (
 	setVisualText: textBeingAccepted.

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -2241,16 +2241,16 @@ createVisual ^ <Alien[HTMLElement]> = (
 		container appendChild: fragment visual].
 	^container
 )
+public crossAxisAlignToStart = (
+	alignItems:: 'flex-start'.
+	childAlignSelf:: nil.
+)
 public crossAxisAlignToCenter = (
 	alignItems:: 'center'.
 	childAlignSelf:: 'center'.
 )
 public crossAxisAlignToEnd = (
 	alignItems:: 'flex-end'.
-	childAlignSelf:: nil.
-)
-public crossAxisAlignToStart = (
-	alignItems:: 'flex-start'.
 	childAlignSelf:: nil.
 )
 public crossAxisStretch = (
@@ -2260,14 +2260,14 @@ public crossAxisStretch = (
 flexDirection ^ <String> = (
   subclassResponsibility
 )
+public mainAxisAlignToStart = (
+	justifyContent:: 'flex-start'.
+)
 public mainAxisAlignToCenter = (
 	justifyContent:: 'center'.
 )
 public mainAxisAlignToEnd = (
 	justifyContent:: 'flex-end'.
-)
-public mainAxisAlignToStart = (
-	justifyContent:: 'flex-start'.
 )
 updateVisualsFromSameKind: oldFragment <SequenceComposer> ^ <Alien[Element]> = (
   | size <Integer> = definitions size. |


### PR DESCRIPTION
The evaluation editor is no longer live. The code is colorized, but no longer evaluated per key press.

Shift-Enter does an evaluation. If there is a selection, the selected text is evaluated.
If there is no selection, all text if evaluated.
If there is no text, nothing happens.

The clear result button is now a standard clear icon button that appears to the right of the evaluations list.

There is no control to evaluate. We could show a control to do this. We could re-use the accept/cancel controls, with accept doing an evaluation and cancel clearing the evaluations list.

Suggestions accepted.