### PR TITLE
Fix Chrome handling of key press

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -316,8 +316,8 @@ registerChangeHandler = (
       editor on: 'change' respondToChange: changeHandler wrappedCallback.
 )
 registerKeyHandler = (
-      keyHandler:: CallBackWrapper wrapping: [:codeMirror :keypress | respondToKeyPress: codeMirror. nil].
-      editor on: 'keypress' respondToKeyPress: keyHandler wrappedCallback.
+      keyHandler:: CallBackWrapper wrapping: [:codeMirror :keydown | respondToKeyDown: codeMirror. nil].
+      editor on: 'keydown' respondToKeyDown: keyHandler wrappedCallback.
 )
 public resetStyles = (
   hasVisual ifFalse: [^self].
@@ -346,7 +346,7 @@ respondToChange: event <Alien[Event]> = (
 		ifTrue: [defaultChangeResponse]
 		ifFalse: [changeResponse cull: self cull: event].
 )
-respondToKeyPress: event <Alien[Event]> = (
+respondToKeyDown: event <Alien[Event]> = (
 	| 
 	key <Character> = (event at: 'key'). 
 	metaPressed <Boolean> = (event at: 'metaKey').
@@ -354,27 +354,31 @@ respondToKeyPress: event <Alien[Event]> = (
 	|
 
 	(isInEditState and: [useEditControls]) ifTrue: [
+        
 		metaPressed ifTrue: [
 			key = 'Enter'
-				ifTrue: [ 			
+				ifTrue: [ 	
+                    event preventDefault.		
 					lastChangeWasSynthetic:: true.	
 					respondToAccept: event.
                     ^self.
 				].
-			
-			key = 'Escape'
-				ifTrue: [
-					lastChangeWasSynthetic:: true.
-					respondToCancel.
-                    ^self.
-				].		
 		].
+
+        key = 'Escape'
+            ifTrue: [
+                event preventDefault.
+                lastChangeWasSynthetic:: true.
+                respondToCancel.
+                ^self.
+            ].	
 	].
 
     shiftPressed ifTrue: [
         key = 'Enter'
             ifTrue: [ 		
                 event preventDefault.
+                lastChangeWasSynthetic:: true.	
                 respondToEvaluate.
                 ^self.
             ].


### PR DESCRIPTION
A journey into the CodeMirror source code informs me keydown is the correct event to handle to properly get modifier keys. 

This change also allows an unadorned Escape keydown to exit/cancel the edit.

Tested on Safari, Chrome, Firefox. Not tested on Opera, Brave, Lynx.