### PR TITLE
Add style cache; move styling to decorate method

### DIFF
--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -124,31 +124,106 @@ Further documentation of subjects and decorators will be added in the future.
     public refreshImage = images refreshImage.
 
 (* Style *)
-	public styleBorderColor <String> = 'silver'.
-	public styleButtonSize <Float> = 30.
-	public styleDefaultInset = '10px'.
-	public styleDefaultInterfaceTextColor = '#3C3C3C'.
-	public styleDefaultEditorTextColor = 'black'.
-	public styleDefaultRadius = '5px'.
-    public styleFontFamilyMonospace = 'ui-monospace, monospace'.
-	public styleFontFamilySansSerif = '-apple-system, sans-serif'.
-	public styleFontFamilySerif = 'serif'.
-	public styleFontSizeEditor = '14px'.
-	public styleFontSizeMenu = '13px'.	
-	public styleFontSizeText = '14px'.
-	public styleMenuBackgroundColor = '#F6F6F6'.
-	public styleMenuBorderColor = '#C7C7C7'.
-	public styleMenuInset = '15px'.	
-	public styleMenuItemHeight = '24px'.	
-	public styleMenuShadowColor = 'darkgrey'.
-	public styleRowHeight = '30px'.
-    public styleTextInputHeight = '24px'.
-	public styleZebraPrimaryColor = Color white.
-	public styleZebraSecondaryColor = Color gray: 0.97.
+    public styleInstance = Style new.	
 	|) (
+class Style = (
+	|
+    public borderColor <String> = 'silver'.
+	public buttonSize <Float> = 30.
+	public defaultInset = '10px'.
+	public defaultInterfaceTextColor = '#3C3C3C'.
+	public defaultEditorTextColor = 'black'.
+	public defaultRadius = '5px'.
+    public fontFamilyMonospace = 'ui-monospace, monospace'.
+	public fontFamilySansSerif = '-apple-system, sans-serif'.
+	public fontFamilySerif = 'serif'.
+	public fontSizeEditor = '14px'.
+	public fontSizeMenu = '13px'.	
+	public fontSizeText = '14px'.
+	public menuBackgroundColor = '#F6F6F6'.
+	public menuBorderColor = '#C7C7C7'.
+	public menuInset = '15px'.	
+	public menuItemHeight = '24px'.	
+	public menuShadowColor = 'darkgrey'.
+	public rowHeight = '30px'.
+    public textInputHeight = '24px'.
+	public zebraPrimaryColor = Color white.
+	public zebraSecondaryColor = Color gray: 0.97.
+
+    private styles = populateStyles.
+    |
+) (
+populateStyles ^ <Map[Symbol, Alien[JSObject]]> = (    
+    ^Map new
+
+        at: #codeEditorStyle put: ((JSObject new)
+            at: 'css' put: 
+                'color:', defaultEditorTextColor, ';',
+                'font-family:', fontFamilySerif, ';',
+                'text-decoration: none; font-weight: normal');
+
+        at: #codeEditorContainer put: ((JSObject new)
+            at: 'style' put:
+                'display:flex', ';',
+                'flex-direction:column', ';',
+                'width:99%', ';',
+                'min-height:', textInputHeight, ';',
+                'background-color: white', ';',
+                'opacity: 1.0', ';',
+                'borderStyle: solid', ';',
+                'borderWidth: 1px', ';',
+                'borderColor:', borderColor, ';'
+            );
+
+        at: #codeEditorControlsContainer put: ((JSObject new)
+            at: 'style' put:
+                'display:flex', ';',
+                'flex-direction:row', ';',
+                'align-items:center', ';',
+                'justify-content:flex-end', ';',
+                'z-index:10', ';',
+                'opacity:0.0', ';',
+                'width:auto', ';',
+                'pointer-events:none', ';'
+            );
+
+        at: #codeEditorControl put: ((JSObject new)
+            at: 'style' put:
+                'width:22px', ';',
+                'pointer-events:auto', ';'
+            );        
+
+        at: #codeEditorMessageContainer put: ((JSObject new)
+            at: 'style' put:
+                'background-color:#FFE6B3', ';',
+                'border-top:1px solid silver', ';',
+                'display:flex', ';',
+                'flex-direction:row', ';',
+                'align-items:left', ';',
+                'vertical-align:middle', ';',
+                'padding-left', defaultInset, ';',
+                'width:100%', ';',
+                'height:20px', ';'
+            );      
+
+        at: #codeEditorTextArea put: ((JSObject new)
+            at: 'style' put:
+                'height:unset', ';',
+                'width:100%', ';',	
+                'background-color:transparent', ';',
+                'font-family:', fontFamilySerif, ';',
+                'font-size:', fontSizeEditor, ';'
+            );      
+
+        yourself
+)
+public style: k <Symbol> ^ <Alien[Object]> = (
+    ^styles at: k ifAbsent: [JSObject new]
+)
+)
 class BlankFragment = LeafFragment (
 ) (
-createVisual = (
+createVisual ^ <Visual> = (
 	^document createElement: 'div'
 )
 public isKindOfBlankFragment ^ <Boolean> = (
@@ -158,7 +233,7 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfBlankFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^oldFragment visual
+    ^oldFragment visual
 )
 ) : (
 )
@@ -167,7 +242,7 @@ class ButtonFragment label: l action: a = LeafFragment (|
 	action = a.
 	public enabled ::= true.
 |) (
-createVisual = (
+createVisual ^ <Visual> = (
 	^(document createElement: 'button')
 		appendChild: (document createTextNode: label);
 		at: 'onclick' put: [:event | action value. false];
@@ -181,12 +256,13 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfButtonFragment
 )
 updateVisualsFromSameKind: oldFragment <ButtonFragment>  ^ <Alien[ButtonElement]> = (
-| oldVisual = oldFragment visual.|
-   oldVisual at: 'onclick' put: [:event | action value. false];
-		 at: 'disabled' put: enabled not.
-   oldFragment label ~= label ifTrue: [
-	oldVisual replaceChild: (document createTextNode: label) oldChild: (oldVisual at:  'firstChild')
-	].
+	| oldVisual = oldFragment visual.|
+   	oldVisual 
+		at: 'onclick' put: [:event | action value. false];
+		at: 'disabled' put: enabled not.
+	oldFragment label ~= label ifTrue: [
+		(oldVisual at: 'firstChild') replaceWith: (document createTextNode: label) 
+    ].
    ^oldVisual
 )
 ) : (
@@ -207,13 +283,16 @@ class CanvasFragment withExtent: e = LeafFragment (
 	|
 	alien at: 'width' put: e x.
 	alien at: 'height' put: e y.
-	(alien at: 'style') at: 'position' put: 'relative'.
 ) (
 public context = (
 	^Context on: (alien getContext: '2d')
 )
-createVisual = (
+createVisual ^ <Visual> = (
 	^alien
+)
+public decorate = (
+    super decorate.
+	(visual at: 'style') at: 'position' put: 'relative'.
 )
 public isKindOfCanvasFragment ^ <Boolean> = (
 	^true
@@ -235,15 +314,13 @@ public mouseMovedAction: onMouseMoved <[:Point]> = (
 		[:event | onMouseMoved value: (event at: 'offsetX') @ (event at: 'offsetY'). nil].
 )
 updateVisualsFromSameKind: oldFragment <CanvasFragment>  ^ <Alien[Canvas]>  = (
-  ^oldFragment visual
+    ^oldFragment visual
 )
 ) : (
 )
 public class CodeMirrorFragment onText: t <String> = LeafFragment (
-(* An experiment to see how to integrate CodeMirror as editor. *)
 |
     public editor <Alien[CodeMirror]>
-	textSlot <TextFragment | String> ::= t.
 	public useEditControls <Boolean> ::= true.
 	public counterfactualBar <Alien[Span]>
 	public messageContainer <Alien[Span]>
@@ -252,12 +329,19 @@ public class CodeMirrorFragment onText: t <String> = LeafFragment (
 	public acceptResponse <[TextEditorFragment]>
 	public cancelResponse <[TextEditorFragment]>
     public evaluateResponse <[TextEditorFragment]>
-	styles ::= List new.
 	public beforeChangeHandler <CallBackWrapper>
 	public changeHandler <CallBackWrapper>
 	public keyHandler <CallBackWrapper>
-	lastChangeWasSynthetic <Boolean> ::= false.
 	public readOnly <Boolean> ::= false.
+
+    textSlot <TextFragment | String> ::= t.
+	styles ::= List new.
+	lastChangeWasSynthetic <Boolean> ::= false.
+    public container <Alien[Div]> 
+	public frame <Alien[Div]> 
+	public accept <Alien[Img]> 
+	public cancel <Alien[Img]> 
+	public textArea <Alien[Span]> 
 |
 ) (
 applyStyle: style <{Integer. Integer. Alien[JSObject]}> = (
@@ -288,12 +372,7 @@ public defaultChangeResponse = (
 	updateEditState
 )
 defaultStyle ^ <Alien[Object]> = (
-	| style <Alien[JSObject]> = JSObject new. |
-	style at: 'css' put: 
-		'color:', styleDefaultEditorTextColor, ';',
-		'font-family:', styleFontFamilySerif, ';',
-		'text-decoration: none; font-weight: normal'.
-    ^style
+    ^ styleInstance style: #codeEditor
 )
 public isKindOfCodeMirrorFragment ^ <Boolean> = (
 	^true
@@ -395,6 +474,46 @@ public text: t = (
 public textBeingAccepted ^ <String> = (
   ^editor getValue
 )
+updateVisualsFromSameKind: oldFragment <CodeMirrorFragment>  ^ <Alien[CodeMirror]> = (
+
+	container:: oldFragment container.
+    frame:: oldFragment frame.
+    accept:: oldFragment accept.
+    cancel:: oldFragment cancel.
+    textArea:: oldFragment textArea.
+    editor:: oldFragment editor.
+    useEditControls:: oldFragment useEditControls.
+    messageContainer:: oldFragment messageContainer.
+    isInEditState:: oldFragment isInEditState.
+	beforeChangeHandler:: oldFragment beforeChangeHandler.
+	changeHandler:: oldFragment changeHandler.
+	keyHandler:: oldFragment keyHandler.
+	readOnly:: oldFragment readOnly.
+        
+    isInEditState 
+        ifTrue: [ 
+            textSlot:: oldFragment editor getValue 
+        ] 
+        ifFalse: [	
+		    lastChangeWasSynthetic:: true.
+		    editor setValue: textSlot.
+		    oldFragment leaveEditState.
+		].
+
+	useEditControls ifTrue: [
+		counterfactualBar:: oldFragment counterfactualBar.
+        (counterfactualBar at: 'firstChild') at: 'onclick' put:
+			[:event | respondToAccept: event. nil].
+		(counterfactualBar at: 'lastChild') at: 'onclick' put:
+			[:event | respondToCancel. nil].
+	].
+
+    beforeChangeHandler callback: [:codeMirror :change | respondToBeforeChange: codeMirror. nil].
+	changeHandler callback: [:codeMirror :change | respondToChange: codeMirror. nil].
+    keyHandler callback: [:codeMirror :keydown | respondToKeyDown: codeMirror. nil].
+
+	^oldFragment visual
+)
 public updateEditState = (
 	lastChangeWasSynthetic ifTrue: [lastChangeWasSynthetic:: false. ^self].
 	
@@ -420,67 +539,32 @@ public hasPendingChanges ^<Boolean> = (
 )
 createVisual = (
 	| 
-	container <Alien[Div]> 
-	frame <Alien[Div]> 
-	accept <Alien[Img]> 
-	cancel <Alien[Img]> 
-	textArea <Alien[Span]> 
-	options <Alien[JSObject]> 
+	options <Alien[JSObject]> = JSObject new.
     |
 
-	container:: document createElement: 'div'.
-	container at: 'id' put: 'CodeMirrorContainer'.
-	(container at: 'style')
-		at: 'display' put: 'flex';
-		at: 'flex-direction' put: 'column';
-		at: 'width' put: '99%';
-		at: 'min-height' put: styleTextInputHeight;
-		at: 'background-color' put: 'white';
-		at: 'opacity' put: 1.0;
-		at: 'borderStyle' put: 'solid';
-		at: 'borderWidth' put: '1px';
-		at: 'borderColor' put: styleBorderColor.
-
+    container:: document createElement: 'div'.
+    container at: 'id' put: 'CodeMirrorContainer'.
+    
 	useEditControls ifTrue: [
 		counterfactualBar:: document createElement: 'div'.
-		(counterfactualBar at: 'style')
-			at: 'display' put: 'flex';
-			at: 'flex-direction' put: 'row';
-			at: 'align-items' put: 'center';
-			at: 'justify-content' put: 'flex-end';
-			at: 'z-index' put: '10';
-			at: 'opacity' put: '0.0';
-			at: 'width' put: 'auto';
-			at: 'pointer-events' put: 'none'.
 
 		accept:: document createElement: 'img'.
 		accept at: 'src' put: (accept16px yourself at: 'src').
-		(accept at: 'style') 
-			at: 'width' put: '22px';
-			at: 'pointer-events' put: 'auto'.
 		accept at: 'onclick' put:
 			[:event | respondToAccept: event. nil].
 		counterfactualBar appendChild: accept.
 
 		cancel:: document createElement: 'img'.
 		cancel at: 'src' put: (cancel16px yourself at: 'src').
-		(cancel at: 'style') 
-			at: 'width' put: '22px';
-			at: 'pointer-events' put: 'auto'.
 		cancel at: 'onclick' put:
 			[:event | respondToCancel. nil].
 		counterfactualBar appendChild: cancel.
+
 		container appendChild: counterfactualBar.
 	].
 
 	frame:: document createElement: 'div'.
 	frame at: 'id' put: 'CodeMirrorFragment'.
-	(frame at: 'style')
-		at: 'display' put: 'flex';
-		at: 'flex-direction' put: 'row'.
-	useEditControls ifTrue: [		
-		(frame at: 'style') at: 'margin-top' put: '-20px'.
-	].
 	container appendChild: frame.
 
 	textArea:: document createElement: 'textarea'.
@@ -489,7 +573,6 @@ createVisual = (
 		at: 'resize' put: true.
 	frame appendChild: textArea.
 
-	options:: JSObject new.
 	options at: 'lineWrapping' put: true.
 	options at: 'readOnly' put: readOnly.
     options at: 'scrollbarStyle' put: 'null'.
@@ -498,69 +581,38 @@ createVisual = (
     registerChangeHandler.
 	registerKeyHandler.
 	
-	((textArea at: 'nextSibling') at: 'style') 
-		at: 'height' put: 'unset';
-		at: 'width' put: '100%';	
-		at: 'background-color' put: 'transparent';
-		at: 'fontFamily' put: styleFontFamilySerif;
-		at: 'font-size' put: styleFontSizeEditor.
-
 	messageContainer:: document createElement: 'div'.
-	(messageContainer at: 'style')
-		at: 'background-color' put: '#FFE6B3';
-		at: 'border-top' put: '1px solid silver';
-		at: 'display' put: 'flex';
-		at: 'flex-direction' put: 'row';
-		at: 'align-items' put: 'left';
-		at: 'vertical-align' put: 'middle';
-		at: 'padding-left' put: styleDefaultInset;
-        at: 'width' put: '100%';
-		at: 'height' put: '20px'.
 
 	^container
 )
-public leaveEditState = (
-	isInEditState ifTrue:
-		[
-		useEditControls ifTrue: [
-			(counterfactualBar at: 'style')
-				at: 'opacity' put: '0.0'.		
-		].
-	    removeMessages.		        
-		isInEditState:: false.
-		]
-)
-updateVisualsFromSameKind: oldFragment <CodeMirrorFragment>  ^ <Alien[CodeMirror]> = (
-	isInEditState:: oldFragment isInEditState.
-	beforeChangeHandler:: oldFragment beforeChangeHandler.
-	changeHandler:: oldFragment changeHandler.
-	keyHandler:: oldFragment keyHandler.
-	editor:: oldFragment editor.
-	readOnly:: oldFragment readOnly.
-      isInEditState ifTrue: [
-		textSlot:: oldFragment editor getValue
-		] ifFalse: [	
-		lastChangeWasSynthetic:: true.
-		editor setValue: textSlot.
-		oldFragment leaveEditState.
-		].
+public decorate = (
+    super decorate.
 
-	useEditControls ifTrue: [
-		counterfactualBar:: oldFragment counterfactualBar.
-		(counterfactualBar at: 'firstChild') at: 'onclick' put:
-			[:event | respondToAccept: event. nil].
-		(counterfactualBar at: 'lastChild') at: 'onclick' put:
-			[:event | respondToCancel. nil].
+    container at: 'style' put: (styleInstance style: #codeEditorContainer).
+
+    counterfactualBar isNil ifFalse: [
+        counterfactualBar at: 'style' put: (styleInstance style: #codeEditorControlsContainer).
+        accept at: 'style' put: (styleInstance style: #codeEditorControl).
+        cancel at: 'style' put: (styleInstance style: #codeEditorControl).
+
+        (isInEditState and: [useEditControls]) ifTrue: [
+            (counterfactualBar at: 'style') 
+                at: 'opacity' put: '1.0'.
+        ].
+    ].
+
+    (frame at: 'style')
+		at: 'display' put: 'flex';
+		at: 'flex-direction' put: 'row'.
+	useEditControls ifTrue: [		
+		(frame at: 'style') at: 'margin-top' put: '-20px'.
 	].
 
-	messageContainer:: oldFragment messageContainer.
+    (textArea at: 'nextSibling') at: 'style' put: (styleInstance style: #codeEditorTextArea).
 
-	beforeChangeHandler callback: [:codeMirror :change | respondToBeforeChange: codeMirror. nil].
-    changeHandler callback: [:codeMirror :change | respondToChange: codeMirror. nil].
-	keyHandler callback: [:codeMirror :change | respondToKeyDown: codeMirror. nil].
-
-	^oldFragment visual
+    messageContainer at: 'style' put: (styleInstance style: #codeEditorMessageContainer).
 )
+
 currentLineNumber ^ <Integer> = (
   ^editor getCursor at: #line
 )
@@ -571,9 +623,8 @@ public currentLine ^ <String> = (
 )
 class ColorDecorator color: c <Color> = Decorator (
 | color <Color> = c. |) (
-public decorate: aVisual = (
-	color applyToStyle: (aVisual at: 'style').
-	^aVisual
+public decorate = (
+	color applyToStyle: (visual at: 'style').
 )
 ) : (
 )
@@ -597,8 +648,8 @@ class Composer = Fragment () (
 public class Decorator = (
 (* A Decorator is attached to a fragment and is called by the fragment to change the various attributes of the Brazil visual created by the fragment itself. *)
 ) (
-public decorate: aVisual = (
-	(* Change properties of aVisual or wrap it into a new visual that applies whatever decorating we represent to aVisual. Answer aVisual or the new visual. *)
+public decorate = (
+	(* Set properties of the visual. *)
 	subclassResponsibility
 )
 ) : (
@@ -613,20 +664,23 @@ public childrenDo: aBlock = (
 	  ifFalse: [aBlock value: contentFragment]
 	  ifTrue: [aBlock value: initialContent]
 )
-createVisual = (
+createVisual ^ <Visual> = (
 	| div initialVisual |
 	div:: document createElement: 'div'.
-    div at: 'id' put: 'CodeMirrorFragment'.
-	(div at: 'style') at: 'align-self' put: 'center'.
+    div at: 'id' put: 'DeferredContentComposer'.
 	initialVisual:: initialContent visual.
 	div appendChild: initialVisual.
+	initialContent decorate.
 	deferAction: [
 		| deferredFragment = contentSource value. |
 		deferredFragment parent: self.
 		contentFragment:: deferredFragment.
-		(* replace: new with: old due to stupid DOM argument ordering *)
-		div replaceChild: deferredFragment visual with: initialVisual].
+		initialVisual replaceWith: deferredFragment visual].
 	^div
+)
+public decorate = (
+    super decorate.
+	(visual at: 'style') at: 'align-self' put: 'center'.
 )
 public isKindOfDeferredContentComposer ^ <Boolean> = (
 	^true
@@ -635,14 +689,14 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfDeferredContentComposer
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  | oldVisual = oldFragment visual. |
-	deferAction: [
-		| deferredFragment = contentSource value. |
+    | oldVisual = oldFragment visual. |
+	    deferAction: [
+        | deferredFragment = contentSource value. |
 		deferredFragment parent: self.
 		contentFragment:: deferredFragment.
-		(* replace: new with: old due to stupid DOM argument ordering *)
-		oldVisual replaceChild: deferredFragment visual replacing: (oldVisual at: 'firstChild')]. 
-	^oldVisual  
+		(oldVisual at: 'firstChild') replaceWith: deferredFragment visual
+    ]. 
+    ^oldVisual  
 )
 ) : (
 )
@@ -660,17 +714,13 @@ Class methods that provide convenient defaults for the button image and the alig
 	alignment <String>  = side asString.
     image = img.
     action = [].
-    width = styleButtonSize.
-    height = styleButtonSize.
+    width = styleInstance buttonSize.
+    height = styleInstance buttonSize.
 	|
 ) (
-createVisual ^ <Alien[Element]> = (
+createVisual ^ <Visual> = (
 	| menu = super createVisual. |
-
 	menu addEventListener: 'click' action: [:event | updateContent. nil].
-	(menu at: 'style')
-		at: 'cursor' put: 'pointer'.
-
     image
         addEventListener: 'mousedown' action:
 		    [:event | (image at: 'style') at: 'filter' put: 'brightness(130%)'. nil];
@@ -678,8 +728,12 @@ createVisual ^ <Alien[Element]> = (
 		    [:event | (image at: 'style') at: 'filter' put: 'brightness(50%)'. nil];
         addEventListener: 'mouseout' action:
 			[:event | (image at: 'style') at: 'filter' put: ''. nil].
-
 	^menu
+)
+public decorate = (
+    super decorate.
+    (visual at: 'style')
+		at: 'cursor' put: 'pointer'.
 )
 public isKindOfDropDownMenuFragment ^ <Boolean> = (
 	^true
@@ -696,7 +750,7 @@ updateContent ^ <Alien[Element]> = (
     ^menu.
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^visual (* optimize later? Does it even matter? *)
+    ^visual (* optimize later? Does it even matter? *)
 )
 ) : (
 public menu: ms  <[Tuple[Symbol | Tuple[String, []]]]> ^ <Instance> = (
@@ -723,16 +777,16 @@ public class EmbeddedHopscotchWindow into: container openSubject: s = HopscotchW
 class ToolbarPresenter = super ToolbarPresenter (
 ) (
 backButton = (
-    ^imageButton: backImage action: [goBack] size: styleButtonSize
+    ^imageButton: backImage action: [goBack] size: styleInstance buttonSize
 )
 forwardButton = (
-    ^imageButton: forwardImage action: [goForward] size: styleButtonSize
+    ^imageButton: forwardImage action: [goForward] size: buttonSize
 )
 futureButton = (
-    ^imageButton: dropDownImage action: [selectFromFuture] size: styleButtonSize
+    ^imageButton: dropDownImage action: [selectFromFuture] size: styleInstance buttonSize
 )
 pastButton = (
-    ^imageButton: dropDownImage action: [selectFromPast] size: styleButtonSize
+    ^imageButton: dropDownImage action: [selectFromPast] size: styleInstance buttonSize
 )
 selectFromPast = (
 	| menuItems = List new. |
@@ -824,13 +878,17 @@ public  chooseSingleFile:  blk <[:Alien[File]]> = (
   allowMultiples ifTrue: [Error signal: 'This chooser may choose multiple files'].
   chooseFileList: [:files <List[Alien[File]]> | blk value: (files at: 1)]
 )
-createVisual = (
+createVisual ^ <Visual> = (
   | v <Visual> = document createElement: 'input'. |
-  (v at: 'style') at: 'display' put: 'none'.
   v at: 'type' put: 'file'; 
 	at: 'multiple' put: allowMultiples; 
 	at: 'id' put: 'newspeakFileChooser_allowMultiples = ', allowMultiples printString.
   ^v
+)
+public decorate = (
+    super decorate.
+    (visual at: 'style')
+        at: 'display' put: 'none'.
 )
 input ^ <Alien[Input]> = (
   hasVisual ifFalse: [^createVisual].
@@ -862,7 +920,7 @@ Another subclass responsibility is #updateVisualsFromSameKind:, which updates th
 (presumably older) fragment of the same kind.
 
 *)
-      |
+    |
 	visualX
 	public parent
 	public size ::= nil.
@@ -875,16 +933,13 @@ public addDecorator: newDecorator <Decorator> = (
 	nil = decorators ifTrue: [decorators:: List new].
 	decorators addLast: newDecorator.
 )
-createVisual = (
+createVisual ^ <Visual> = (
 	subclassResponsibility
 )
-public decorate: aVisual = (
+public decorate = (
 	(* The argument is a visual freshly created by the #createVisual or #createViewportWithVisual method. If we have any decorators attached, apply them now to arrive at the final decorated visual. *)
 	| decorated |
-	decorated:: aVisual.
-	nil = decorators ifFalse:
-		[decorators do: [:each | decorated:: each decorate: decorated]].
-	^decorated
+	nil = decorators ifFalse: [decorators do: [:each | decorated:: each apply: visual]].
 )
 public elasticity: x = (
 	expansibility: x.
@@ -919,9 +974,9 @@ public refresh = (
 	childrenDo: [:each | each refresh]
 )
 public replaceVisual: oldVisual <Alien[Element]> with: newVisual <Alien[Element]>  = (
-  | oldParent <Alien[Node]> = oldVisual at: 'parentNode'. | 
-  oldParent isNil ifFalse: [oldParent replaceChild: newVisual replacing: oldVisual].
-  ^newVisual
+	| oldParent <Alien[Node]> = oldVisual at: 'parentNode'. | 
+	oldParent isNil ifFalse: [oldVisual replaceWith: newVisual].	
+	^newVisual
 )
 public shell = (
 	^parent isNil
@@ -936,11 +991,14 @@ updateGUI: action <[Object]> = (
   ^nil
 )
 public updateVisualsFrom: oldFragment <Fragment> = (
-  (isMyKind: oldFragment) ifTrue: [
-    visualX:: oldFragment hasVisual ifTrue: [updateVisualsFromSameKind: oldFragment]
-  ] ifFalse: [
-    replaceVisual: oldFragment visual with: visual
-  ]
+	(isMyKind: oldFragment) 
+		ifTrue: [
+			visualX:: oldFragment hasVisual ifTrue: [
+			updateVisualsFromSameKind: oldFragment.
+		]] 
+		ifFalse: [
+    		replaceVisual: oldFragment visual with: visual.
+		]
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 (* 
@@ -956,7 +1014,9 @@ public value = (
 	^self
 )
 public visual = (
-	visualX isNil ifTrue: [visualX:: decorate: createVisual].
+	visualX isNil ifTrue:  [
+		visualX:: createVisual.
+	].
 	^visualX
 )
 public width: w elasticity: e = (
@@ -1015,7 +1075,7 @@ forgetEntry: aPresenter = (
 forgetEntryUIFor: aPresenter = (
 	 ^imageButton: clearImage 
 	 			   action: [updateGUI: [forgetEntry: aPresenter]] 
-	  			   size: styleButtonSize
+	  			   size: styleInstance buttonSize
 )
 public isKindOfHistoryPresenter ^ <Boolean> = (
   ^true
@@ -1073,10 +1133,12 @@ public title = (
 )
 ) : (
 )
-class HolderComposer withContent: definition <Fragment | [Fragment]> = Composer (|
+class HolderComposer withContent: definition <Fragment | [Fragment]> = Composer (
+	|
 	contentSource <Fragment | [Fragment]> ::= definition.
 	actualContent <Fragment>
-|) (
+	|	
+) (
 public childrenDo: aBlock <[:Fragment]> = (
 	nil = actualContent ifFalse: [aBlock value: actualContent].
 )
@@ -1087,25 +1149,30 @@ public content ^<Fragment> = (
 	^actualContent
 )
 public content: fragment = (
- | oldContent newContent |
+    | oldContent newContent |
 	fragment parent: self.
-	hasVisual ifTrue:
-		[
-		oldContent:: actualContent.
-		newContent:: actualContent:: fragment.
-		(* replace: new with: old due to stupid DOM argument ordering *)
-		assert: [oldContent visual contains: (visual at: 'firstChild')] message: 'holder invariant broken 1'.
-		visual replaceChild: newContent visual with: oldContent visual.
-		assert: [actualContent visual contains: (visual at: 'firstChild')] message: 'holder invariant broken2'.	
-		]
-	ifFalse: [contentSource:: actualContent:: fragment]
+	hasVisual 
+        ifTrue: [
+            oldContent:: actualContent.
+            newContent:: actualContent:: fragment.
+            assert: [oldContent visual contains: (visual at: 'firstChild')] message: 'holder invariant broken 1'.
+            oldContent visual replaceWith: newContent visual.
+            assert: [actualContent visual contains: (visual at: 'firstChild')] message: 'holder invariant broken2'.	
+        ]
+	    ifFalse: [
+			contentSource:: actualContent:: fragment.
+		].	
+    decorate
 )
-createVisual = (
-	| div |
-	div:: document createElement: 'div'.
+createVisual ^ <Visual> = (
+	| div = document createElement: 'div'. |
     div at: 'id' put: 'HolderComposer'.
 	div appendChild: content visual.
 	^div
+)
+public decorate = (
+	super decorate.
+	actualContent decorate.	
 )
 public isKindOfHolderComposer ^ <Boolean> = (
 	^true
@@ -1118,21 +1185,23 @@ public noticeExposure = (
 )
 public refresh = (
 	(contentSource isKindOfClosure and: [hasVisual])
-		ifTrue:
-			[ | oldContent newContent |
+		ifTrue: [ 
+            | oldContent newContent |
 			oldContent:: actualContent.
 			actualContent:: nil.
 			newContent:: content.
-			(* replace: new with: old due to stupid DOM argument ordering *)
-			visual replaceChild: newContent visual with: oldContent visual.
+			oldContent visual replaceWith: newContent visual.
+            decorate.
 			]
-		ifFalse:
-			[actualContent refresh].
+		ifFalse: [
+            actualContent refresh.
+            decorate.
+        ].   
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  content updateVisualsFrom: oldFragment content.
-   assert: [actualContent visual contains: (oldFragment visual at: 'firstChild')] message: 'holder invariant broken 3'.
-  ^oldFragment visual
+    content updateVisualsFrom: oldFragment content.
+    assert: [actualContent visual contains: (oldFragment visual at: 'firstChild')] message: 'holder invariant broken 3'.    
+    ^oldFragment visual
 )
 ) : (
 )
@@ -1259,8 +1328,17 @@ public displayPresenter: p = (
     assert: [p creatingWindow isNil or: [p creatingWindow = self]] message: 'Error: Attempt to display presenter from another window'.
 	p parent: self.
 	contentHolder hasChildNodes
-		ifTrue: [contentHolder replaceChild: p visual from: (contentHolder at: 'firstChild')]
-		ifFalse: [contentHolder appendChild: p visual].
+		ifTrue: [
+            | 
+            oldVisual = (contentHolder at: 'firstChild'). 
+            newVisual = p visual.
+            |
+            oldVisual replaceWith: newVisual.
+        ]
+		ifFalse: [
+            contentHolder appendChild: p visual
+        ].
+	p decorate.
 	p noticeExposure.
 )
 public registerNewPresenter: newPresenter <Presenter> = (
@@ -1301,10 +1379,13 @@ userBack: event = (
 ) : (
 )
 public class HopscotchWindow into: container openSubject: s = HopscotchShell (
+	| toolbar |
 	listenForBackButton.
 	container appendChild: toolbarHolder.
 	container appendChild: contentHolder.
-    toolbarHolder appendChild: ToolbarPresenter new visual.
+	toolbar:: ToolbarPresenter new.
+    toolbarHolder appendChild: toolbar visual.
+	toolbar decorate.
 	enterSubject: s.
 ) (
 class ToolbarPresenter = Presenter onSubject: nil (
@@ -1316,20 +1397,20 @@ definition ^ <Fragment> = (
     }
 )
 historyButton ^ <ButtonFragment> = (
-  ^imageButton: historyImage action: [showHistory] size: styleButtonSize
+  ^imageButton: historyImage action: [showHistory] size: styleInstance buttonSize
 )
 toolbarItems ^ <Array[Fragment]>  = (
- ^{filler. historyButton. smallBlank. homeButton. smallBlank. refreshButton. smallBlank}
+ 	^{filler. historyButton. smallBlank. homeButton. smallBlank. refreshButton. smallBlank}
 )
 refreshButton ^ <ButtonFragment> = (
-^imageButton: refreshImage action: [outer HopscotchWindow refresh] size: styleButtonSize
+	^imageButton: refreshImage action: [outer HopscotchWindow refresh] size: styleInstance buttonSize
 )
 enterSubject: s <Subject> = (
 (* workaround so we can conveniently enter subjects, even though this presenter is not installed in a shell. *)
-  ^outer HopscotchWindow enterSubject: s
+	^outer HopscotchWindow enterSubject: s
 )
 shell ^ <HopscotchWindow> = (
-  ^outer HopscotchWindow shell
+	^outer HopscotchWindow shell
 )
 ) : (
 )
@@ -1359,32 +1440,23 @@ public openSubject: s = (
 )
 )
 class HyperlinkFragment label: l action: a = LeafFragment (|
+    public container <Alien[Element]>
+    public anchor <Alien[Element]>
 	public label = l.
-	action = a.
 	public color ::= Color r: 0 g: 0 b: 1.
+    action = a.
+
 |) (
-createVisual = (
-	| 
-    container = document createElement: 'div'.
-    anchor = document createElement: 'a'.
-    |
+createVisual ^ <Visual> = (
 
+    container:: document createElement: 'div'.
     container at: 'id' put: 'HyperlinkFragmentContainer'.
-    (container at: 'style')
-        at: 'display' put: 'flex';
-        at: 'flex-direction' put: 'column';
-        at: 'justify-content' put: 'center';
-        at: 'min-height' put: styleRowHeight;
-        at: 'cursor' put: 'pointer'.
 
+    anchor:: document createElement: 'a'.
     anchor at: 'id' put: 'HyperlinkFragment'.
 	anchor at: 'href' put: '#'.
 	anchor appendChild: (document createTextNode: label).
 	anchor at: 'onclick' put: [:event | action value. false].
-	(anchor at: 'style')
-		at: 'textDecoration' put: 'none'; (* No underline *)
-		at: 'overflow' put: 'hidden';
-        at: 'white-space' put: 'nowrap'.
 
     anchor
         addEventListener: 'mouseover' action:
@@ -1392,12 +1464,26 @@ createVisual = (
         addEventListener: 'mouseout' action:
             [:event | (anchor at: 'style') at: 'textDecoration' put: 'none'. nil].
 
-	color isNil ifFalse:
-		[(anchor at: 'style') setProperty: 'color' to: color asCSSString].
-
     container appendChild: anchor.
     
 	^container
+)
+public decorate = (
+    super decorate.
+    (container at: 'style')
+        at: 'display' put: 'flex';
+        at: 'flex-direction' put: 'column';
+        at: 'justify-content' put: 'center';
+        at: 'min-height' put: styleInstance rowHeight;
+        at: 'cursor' put: 'pointer'.
+
+	(anchor at: 'style')
+		at: 'textDecoration' put: 'none';
+		at: 'overflow' put: 'hidden';
+        at: 'white-space' put: 'nowrap'.
+
+	color isNil ifFalse:
+		[(anchor at: 'style') setProperty: 'color' to: color asCSSString].
 )
 public isKindOfHyperlinkFragment ^ <Boolean> = (
 	^true
@@ -1409,17 +1495,9 @@ public smallFont = (
 	(visual at: 'style') at: 'font-size' put: 'smaller'
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  | oldVisual = oldFragment visual.|
-  oldVisual at: 'onclick' put: [:event | action value. false].
-  label ~= oldFragment label ifTrue: [
-	oldVisual replaceChild: (document createTextNode: label) replacing: (oldVisual at: 'firstChild').
-	].
-
-   color ~= oldFragment color ifTrue: [
-	color isNil ifFalse:
-		[(oldVisual at: 'style') setProperty: 'color' to: color asCSSString].
-	].
-  ^oldVisual
+    container:: oldFragment container.
+    anchor:: oldFragment anchor.
+    ^oldFragment visual
 )
 ) : (
 )
@@ -1427,9 +1505,8 @@ class HyperlinkImageFragment image: i action: a = LeafFragment (|
 	image = i.
 	action =  a.
 |) (
-createVisual = (
-	| img |
-	img:: image cloneNode: false (* Not deep *).
+createVisual ^ <Visual> = (
+	| img = image cloneNode: false. |
 	img at: 'onclick' put: [:event | action value. false].
 	^img
 )
@@ -1440,7 +1517,7 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfHyperlinkImageFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^visual (* optimize later? Does it even matter? *)
+    ^visual (* optimize later? Does it even matter? *)
 )
 ) : (
 )
@@ -1451,30 +1528,14 @@ class ImageButtonFragment = LeafFragment (
 	public image <Image>
     public width <Float> ::= -1.
     public height <Float> ::= -1.
-    widthStyle <String> ::= 'auto'.
-    heightStyle <String> ::= 'auto'.
+    public img <Image>
 |) (
 createVisual ^ <Visual> = (
-	| div img |
-	div:: document createElement: 'div'.
-    div at: 'id' put: 'ImageButtonFragment'.
-	(div at: 'style')
-		at: 'display' put: 'flex';
-		at: 'flex-direction' put: 'flex-column';		
-		at: 'align-items' put: 'center';
-		at: 'cursor' put: 'pointer'.
+	| div = document createElement: 'div'. |
+	div at: 'id' put: 'ImageButtonFragment'.
+
     img:: image cloneNode: false (* Not deep *).
-
-    width = -1 ifFalse: [ widthStyle:: width printString, 'px' ].
-    height = -1 ifFalse: [ heightStyle:: height printString, 'px' ].
-
-	(img at: 'style')
-		at: 'width' put: widthStyle;
-		at: 'height' put: heightStyle;
-        at: 'object-fit' put: 'contain'.
-
     img at: 'onclick' put: [:event | action value. false].
-
     img
         addEventListener: 'mousedown' action:
 		    [:event | (img at: 'style') at: 'filter' put: 'brightness(120%)'. nil];
@@ -1486,6 +1547,26 @@ createVisual ^ <Visual> = (
 	div appendChild: img.
 	^div
 )
+public decorate = (
+    |
+    widthStyle <String> ::= 'auto'.
+    heightStyle <String> ::= 'auto'.
+    |
+    super decorate.
+    (visual at: 'style')
+		at: 'display' put: 'flex';
+		at: 'flex-direction' put: 'flex-column';		
+		at: 'align-items' put: 'center';
+		at: 'cursor' put: 'pointer'.
+
+    width = -1 ifFalse: [ widthStyle:: width printString, 'px' ].
+    height = -1 ifFalse: [ heightStyle:: height printString, 'px' ].
+
+	(img at: 'style')
+		at: 'width' put: widthStyle;
+		at: 'height' put: heightStyle;
+        at: 'object-fit' put: 'contain'.
+)
 public isKindOfImageButtonFragment ^ <Boolean> = (
 	^true
 )
@@ -1493,10 +1574,12 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfImageButtonFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-| oldVisual = oldFragment visual. img = oldVisual at: 'firstChild'.|
-  #BOGUS.  (* what if the actual image is different? *)
-   img at: 'onclick' put: [:event | action value. false].
-   ^oldVisual
+    image:: oldFragment image.
+    width:: oldFragment width.
+    height:: oldFragment height.
+    img:: oldFragment img.
+    img at: 'onclick' put: [:event | action value. false].
+    ^oldFragment visual
 )
 ) : (
 )
@@ -1622,8 +1705,8 @@ public registerNewPresenter: newPresenter <Presenter>  = (
 	] 
      ifFalse: [ | id <Number> = idFor: oldPresenter.|
 	(* update the new presenter state based on the old presenter *)
-	  newPresenter updateVisualsFrom: oldPresenter.
-(*	  'Updated visuals' out. *)
+    newPresenter updateVisualsFrom: oldPresenter.
+    (*'Updated visuals' out. *)
 	(* update the cached history to contain the new presenter *)
 	  ids removeKey: oldPresenter.
 	  ids at: newPresenter put: id.
@@ -1827,18 +1910,22 @@ class PaddedFrameComposer content: c offsets: o = Composer (|
 public childrenDo: aBlock = (
 	nil = content ifFalse: [aBlock value: content]
 )
-createVisual = (
+createVisual ^ <Visual> = (
 	| div = document createElement: 'div'. |
     div at: 'id' put: 'PaddedFrameComposer'.
-	(div at: 'style')
+	content parent: self.
+	div appendChild: content visual.
+	^div
+)
+public decorate = (
+    super decorate.
+    (visual at: 'style')
 		at: 'paddingLeft' put: (offsets at: 1) printString, 'px';
 		at: 'paddingTop' put: (offsets at: 2) printString, 'px';
 		at: 'paddingRight' put: (offsets at: 3) printString, 'px';
 		at: 'paddingBottom' put: (offsets at: 4) printString, 'px'.
-	color isNil ifFalse: [color applyToStyle: (div at: 'style')].
-	content parent: self.
-	div appendChild: content visual.
-	^div
+	color isNil ifFalse: [color applyToStyle: (visual at: 'style')].
+	childrenDo: [:child <Fragment> | child decorate].
 )
 public isKindOfPaddedFrameComposer ^ <Boolean> = (
 	^true
@@ -1847,12 +1934,12 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfPaddedFrameComposer
 )
 updateVisualsFromSameKind: oldFragment <PaddedFrameComposer> ^ <Alien[Element]> = (
-  content parent: self.
-  content updateVisualsFrom: oldFragment content.
-  color ~= oldFragment color ifTrue: [
-	color isNil ifFalse: [color applyToStyle: (oldFragment visual at: 'style')].
+	content parent: self.
+	content updateVisualsFrom: oldFragment content.
+	color ~= oldFragment color ifTrue: [
+		color isNil ifFalse: [color applyToStyle: (oldFragment visual at: 'style')].
 	].
-  ^oldFragment visual
+	^oldFragment visual
 )
 ) : (
 )
@@ -1929,6 +2016,10 @@ column: definitions <List[Fragment]> ^ <ColumnComposer> = (
 createVisual ^ <Alien[HTMLElement]> = (
    ^substance visual
 )
+public decorate = (
+    super decorate.
+	substance decorate.
+)
 public creatingWindow ^ <HopscotchWindow> = (
   ^parent isNil ifFalse: [shell]
 )
@@ -1955,10 +2046,10 @@ elastic: aFragment = (
 	^aFragment
 )
 ensureSubstance = (
-	nil = substanceSlot ifTrue:
-		[substanceSlot:: self definition.
+	nil = substanceSlot ifTrue: [substanceSlot:: self definition.
 		substanceSlot parent: self.
-		noticeSubstanceCreation]
+		noticeSubstanceCreation
+	]
 )
 enterPresenter: s = (
 	(* TODO: use sendUp and open a new window if undelivered *)	
@@ -1994,7 +2085,7 @@ holder: def <Fragment | [Fragment]> = (
 	^HolderComposer withContent: def
 )
 homeButton = (
-	^imageButton: homeImage action: [enterSubject: homeSubjectClass new] size: styleButtonSize
+	^imageButton: homeImage action: [enterSubject: homeSubjectClass new] size: styleInstance buttonSize
 )
 image: image <Image> = (
 	| fragment <StaticImageFragment> |
@@ -2165,7 +2256,7 @@ public title ^<String> = (
 	^subject title
 )
 toggleList: ts <Sequence[ToggleComposer]> ^ <ToggledList> = (
-  ^ToggledListFragment ofToggles: ts
+    ^ToggledListFragment ofToggles: ts
 )
 updateVisualsFromSameKind: oldPresenter <Self> ^ <Alien[Element]> = (
 (* A Presenter's visual is determined by its substance, so by default we 
@@ -2174,8 +2265,8 @@ updateVisualsFromSameKind: oldPresenter <Self> ^ <Alien[Element]> = (
   or if there are semantic reasons that make correlating the substances
   difficult or impossible.
 *)
-  substance updateVisualsFrom: oldPresenter substance.
- ^substance visual
+    substance updateVisualsFrom: oldPresenter substance.
+    ^substance visual
 )
 zebra: sequence <Sequence[Fragment]> ^ <Sequence[Fragment]> = (
 	sequence addDecorator: ZebraDecorator lighterColorFirst.
@@ -2207,10 +2298,17 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfRowComposer
 )
 createVisual ^ <Alien[HTMLElement]> = (
-	| visual = super createVisual. |
+	super createVisual.
+    container at: 'id' put: 'RowComposer'.
+	^container
+)
+public decorate = (
+    super decorate.
 	(visual at: 'style')
-		at: 'font-size' put: styleFontSizeText.
-	^visual
+		at: 'font-size' put: styleInstance fontSizeText.	
+
+	definitions do: [:fragment <Fragment> |
+		fragment decorate.]
 )
 ) : (
 )
@@ -2221,12 +2319,14 @@ class SequenceComposer definitions: fs <List[Fragment]> = Composer (|
 	protected childAlignSelf ::= 'center'.
 	protected justifyContent ::= 'flex-start'.
 	protected font ::= 'serif'.
-	protected fontSize ::= styleFontSizeText.
+	protected fontSize ::= styleInstance fontSizeText.
+    container <Alien[HTMLElement]>
 |) (
 alignFragment: fragment  <Fragment> = (
 	| cell <Alien[HTMLElement]> |
 	cell:: fragment visual.
-	(cell at: 'style')
+    
+    (cell at: 'style')
 		at: 'overflow' put: 'hidden';
 		at: 'align-self' put: childAlignSelf;
 		at: 'flex-grow' put: fragment expansibility;
@@ -2239,10 +2339,17 @@ public childrenDo: aBlock = (
 	definitions do: aBlock
 )
 createVisual ^ <Alien[HTMLElement]> = (
-	| container <Alien[HTMLElement]> |
 	container:: document createElement: 'div'.
     container at: 'id' put: 'SequenceComposer'.
-	(container at: 'style')
+	definitions do: [:fragment <Fragment> |
+		fragment parent: self.
+		container appendChild: fragment visual.
+	].
+	^container
+)
+public decorate = (
+    super decorate.
+	(visual at: 'style')
 		at: 'overflow' put: 'hidden';
 		at: 'display' put: 'flex';
 		at: 'flex-direction' put: flexDirection;
@@ -2251,12 +2358,11 @@ createVisual ^ <Alien[HTMLElement]> = (
 		at: 'font-family' put: font;
 		at: 'font-size' put: fontSize.
 	nil = color ifFalse:
-		[color applyToStyle: (container at: 'style')].
+		[color applyToStyle: (visual at: 'style')].
+
 	definitions do: [:fragment <Fragment> |
-		fragment parent: self.
-		alignFragment: fragment.
-		container appendChild: fragment visual].
-	^container
+		fragment decorate.
+		alignFragment: fragment.].
 )
 public crossAxisAlignToStart = (
 	alignItems:: 'flex-start'.
@@ -2287,11 +2393,11 @@ public mainAxisAlignToEnd = (
 	justifyContent:: 'flex-end'.
 )
 updateVisualsFromSameKind: oldFragment <SequenceComposer> ^ <Alien[Element]> = (
-  | size <Integer> = definitions size. |
+    | size <Integer> = definitions size. |
 (* We cannot, in general, know whether the elements of the sequence correlate
     However, if the sequences have the same length they might. 
  *)
-  size = oldFragment definitions size ifTrue: [
+    size = oldFragment definitions size ifTrue: [
 	(* Assume the common case: elements are in 1:1 correspondence. *)
 	1 to: size do: [:i <Integer> | 
 		| def = definitions at: i. |
@@ -2299,9 +2405,9 @@ updateVisualsFromSameKind: oldFragment <SequenceComposer> ^ <Alien[Element]> = (
 		def updateVisualsFrom: (oldFragment definitions at: i).
 		alignFragment: def.
 		].
-	color ~= oldFragment color ifTrue: [
-	  color isNil ifFalse: [color applyToStyle: (oldFragment visual at: 'style')].
-	  ].
+    color ~= oldFragment color ifTrue: [
+        color isNil ifFalse: [color applyToStyle: (oldFragment visual at: 'style')].
+    ].
 	^oldFragment visual
 	].
   (* If the sizes differ, the oldFragment was not produced by the same code and we will compute our visual from scratch *)
@@ -2346,7 +2452,7 @@ public registerNewPresenter: newPresenter <Presenter>  = (
      ifFalse: [ | id <Number> = idFor: oldPresenter.|
 	(* update the new presenter state based on the old presenter *)
 	  newPresenter updateVisualsFrom: oldPresenter.
-(*	  'Updated visuals' out. *)
+(*'Updated visuals' out. *)
 	(* update the cached history to contain the new presenter *)
 	  ids removeKey: oldPresenter.
 	  ids at: newPresenter put: id.
@@ -2356,31 +2462,37 @@ public registerNewPresenter: newPresenter <Presenter>  = (
 ) : (
 )
 class StaticImageFragment image: i = LeafFragment (|
-	public image = i.
+	public source <Image> = i.
     public width <Float> ::= -1.
     public height <Float> ::= -1.
+    public image <Image>
+|) (
+createVisual ^ <Visual> = (
+	| div = document createElement: 'div'. |
+    div at: 'id' put: 'StaticImageFragment'.
+	image:: source cloneNode: false. (* Not deep *)
+	div appendChild: image.
+	^div
+)
+public decorate = (
+    |
     widthStyle <String> ::= 'auto'.
     heightStyle <String> ::= 'auto'.
-|) (
-createVisual = (
-	| div img |
-	div:: document createElement: 'div'.
-    div at: 'id' put: 'StaticImageFragment'.
-	(div at: 'style')
+    |
+    super decorate.	
+	
+    (visual at: 'style')
 		at: 'display' put: 'flex';
 		at: 'flex-direction' put: 'flex-column';
 		at: 'align-items' put: 'center'.
-	img:: image cloneNode: false. (* Not deep *)
 
     width = -1 ifFalse: [ widthStyle:: width printString, 'px' ].
     height = -1 ifFalse: [ heightStyle:: height printString, 'px' ].
 
-	(img at: 'style')
+	(image at: 'style')
 		at: 'width' put: widthStyle;
 		at: 'height' put: heightStyle;
         at: 'object-fit' put: 'contain'.
-	div appendChild: img.
-	^div
 )
 public isKindOfStaticImageFragment ^ <Boolean> = (
 	^true
@@ -2389,11 +2501,17 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfStaticImageFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> = (
-  | oldVisual = oldFragment visual. |
-  oldFragment image ~= image ifTrue: [
-	oldVisual replaceChild: ( image cloneNode: false) replacing: (oldVisual at: 'firstChild').
+    | oldVisual = oldFragment visual. |
+
+    width:: oldFragment width.
+    height:: oldFragment height.
+    image:: oldFragment image.
+
+    oldFragment source ~= source ifTrue: [
+        image:: (source cloneNode: false).
+	    (oldVisual at: 'firstChild') replaceWith: image.
 	].
-  ^oldVisual
+    ^oldVisual
 )
 ) : (
 )
@@ -2403,18 +2521,23 @@ class StaticLabelFragment text: t = LeafFragment (
     public weight ::= #normal.
 	public color
     |) (
-createVisual = (
+createVisual ^ <Visual> = (
 	| div = document createElement: 'div'. |
     div at: 'id' put: 'StaticLabelFragment'.
-	(div at: 'style')
+	div at: 'textContent' put: text.
+	^div
+)
+public decorate = (
+    super decorate.
+	(visual at: 'style')
 		at: 'overflow' put: 'hidden';
 		at: 'white-space' put: 'pre';
         at: 'font-weight' put: weight asString.
-	div at: 'textContent' put: text.
+
 	nil = color ifFalse:
-		[(div at: 'style') setProperty: 'color' to: color asCSSString].
-	^div
+		[(visual at: 'style') setProperty: 'color' to: color asCSSString].    
 )
+
 public isKindOfStaticLabelFragment ^ <Boolean> = (
 	^true
 )
@@ -2432,7 +2555,8 @@ public text: newText = (
 	hasVisual ifTrue: [visual at: 'textContent' put: textX]
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^replaceVisual: oldFragment visual with: visual (* optimize later? Does it even matter? *)
+    (* optimize later? Does it even matter? *)
+    ^replaceVisual: oldFragment visual with: visual 
 )
 ) : (
 )
@@ -2473,8 +2597,8 @@ public title ^<String> = (
 public presenter ^<Presenter> = (
 	presenterSlot isNil ifTrue: [presenterSlot:: createPresenter].
 	presenterSlot generation < uiGeneration ifTrue: [
-		presenterSlot:: createPresenter.
-		].
+		(*presenterSlot:: createPresenter.*)
+	].
 	^presenterSlot
 )
 ) : (
@@ -2482,7 +2606,7 @@ public presenter ^<Presenter> = (
 class TextBlockFragment onText: t <Text> subfragments: sfs <List[Fragment]> = TextFragment onText: t (
 (* A fragment representing a compound text . *)
 | subfragments <List[Fragment]> = sfs. |) (
-createVisual = (
+createVisual ^ <Visual> = (
 	| span = document createElement: 'span'. |
     span at: 'id' put: 'TextBlockFragment'.
 	text textProperties applyTo: span.
@@ -2524,19 +2648,23 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfTextBlockFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^replaceVisual: oldFragment visual with: visual (* optimize later? Does it even matter? *)
+    (* optimize later? Does it even matter? *)
+    ^replaceVisual: oldFragment visual with: visual 
 )
 ) : (
 )
 class TextDisplayFragment text: t = LeafFragment (|
 	textX ::= t.
 |) (
-createVisual = (
+createVisual ^ <Visual> = (
 	| div = document createElement: 'div'. |
     div at: 'id' put: 'TextDisplayFragment'.
-	(div at: 'style') setProperty: 'white-space' to: 'pre-wrap'.
 	div at: 'textContent' put: textX.
 	^div
+)
+public decorate = (
+    super decorate.
+    (visual at: 'style') setProperty: 'white-space' to: 'pre-wrap'.
 )
 public isKindOfTextDisplayFragment ^ <Boolean> = (
 	^true
@@ -2555,61 +2683,53 @@ public text: newText = (
 	hasVisual ifTrue: [visual at: 'textContent' put: textX]
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^replaceVisual: oldFragment visual with: visual (* optimize later? Does it even matter? *)
+    (* optimize later? Does it even matter? *)
+    ^replaceVisual: oldFragment visual with: visual 
 )
 ) : (
 )
-public class TextFieldFragment = TextEditorFragment (|
-|) (
-createVisual = (
-        | editor = super createVisual. |
-        ^editor
-    )
-) : (
+public class SearchFieldFragment = TextEditorFragment (
+    | find <Image> |
+) (
+createVisual ^ <Visual> = (
+    |  editor = super createVisual. |
+    editor addEventListener: 'keydown' action: 
+        [:event | respondToKeyDown: event. nil].
+
+    find:: document createElement: 'img'.
+    find at: 'src' put: (findImage yourself at: 'src').
+    find at: 'onclick' put:
+        [:event | respondToAccept: event. nil].
+    editor appendChild: find.
+        
+    ^editor
 )
-public class SearchFieldFragment = TextFieldFragment (|
-|) (
-createVisual = (
-        | 
-		editor = super createVisual. 
-		find = document createElement: 'img'.
-		|
-
-        (editor at: 'style')
-			at: 'borderStyle' put: 'solid';
-			at: 'borderWidth' put: '1px';
-			at: 'borderColor' put: styleBorderColor;
-            at: 'borderRadius' put: styleDefaultRadius;
-			at: 'background-color' put: 'white'.
-
-		editor addEventListener: 'keydown' action: 
-			[:event | respondToKeyDown: event. nil].
-
-        (textEditor at: 'style')
-            at: 'line-height' put: '24px';
-            at: 'display' put: 'block';
-            at: 'outline' put: 0;
-            at: 'white-space' put: 'nowrap';
-            at: 'fontFamily' put: styleFontFamilySansSerif;
-            at: 'font-size' put: styleFontSizeEditor;
-			at: 'color' put: 'dimgray';
-			at: 'padding-left' put: '8px';
-            at: 'min-width' put: '25vw';
-            at: 'max-width' put: '80vw';   
-            at: 'min-height' put: styleTextInputHeight;
-            at: 'max-height' put: styleTextInputHeight.
-
-		find at: 'src' put: (findImage yourself at: 'src').
-		(find at: 'style') 
-			at: 'width' put: styleTextInputHeight;
-			at: 'height' put: styleTextInputHeight;
-			at: 'cursor' put: 'pointer'.
-		find at: 'onclick' put:
-			[:event | respondToAccept: event. nil].
-		editor appendChild: find.
-			
-        ^editor
-    )
+public decorate = (
+    super decorate.
+    (visual at: 'style')
+        at: 'borderStyle' put: 'solid';
+        at: 'borderWidth' put: '1px';
+        at: 'borderColor' put: styleInstance borderColor;
+        at: 'borderRadius' put: styleInstance defaultRadius;
+        at: 'background-color' put: 'white'.
+    (textEditor at: 'style')
+        at: 'line-height' put: '24px';
+        at: 'display' put: 'block';
+        at: 'outline' put: 0;
+        at: 'white-space' put: 'nowrap';
+        at: 'fontFamily' put: styleInstance fontFamilySansSerif;
+        at: 'font-size' put: styleInstance fontSizeEditor;
+        at: 'color' put: 'dimgray';
+        at: 'padding-left' put: '8px';
+        at: 'min-width' put: '25vw';
+        at: 'max-width' put: '80vw';   
+        at: 'min-height' put: styleInstance textInputHeight;
+        at: 'max-height' put: styleInstance textInputHeight.
+    (find at: 'style') 
+        at: 'width' put: styleInstance textInputHeight;
+        at: 'height' put: styleInstance textInputHeight;
+        at: 'cursor' put: 'pointer'.
+)
 respondToKeyDown: event <Alien[Event]> = (
 		| 
 		keyCode <Character> = (event at: 'keyCode'). 
@@ -2639,22 +2759,23 @@ public class TextEditorFragment = LeafFragment (|
 	public cancelResponse <[TextEditorFragment]>
 	public oldText <TextFragment | String>
 |) (
-createVisual = (
+createVisual ^ <Visual> = (
 	|  frame = document createElement: 'div'. |
     frame at: 'id' put: 'TextEditorFragment'.
-	(frame at: 'style')
-		at: 'display' put: 'flex'.
 	textEditor:: document createElement: 'div'.
 	textEditor at: 'contentEditable' put: 'true'.
-	(textEditor at: 'style')
-		at: 'flex' put: 1.
-
     setText: textX.
 	textEditor addEventListener: 'input' action: 
 		[:event | respondToChange: event. nil].
 	
 	frame appendChild: textEditor.
 	^frame
+)
+public decorate = (
+    (visual at: 'style')
+		at: 'display' put: 'flex'.
+	(textEditor at: 'style')
+		at: 'flex' put: 1.
 )
 public cursorPosition ^ <Integer> = (
 (* BOGUS. This leads to quirks when cutting and pasting. We really need to get the selection from the browser and identify
@@ -2757,14 +2878,15 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfTextFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^replaceVisual: oldFragment visual with: visual (* optimize later? Does it even matter? *)
+    (* optimize later? Does it even matter? *)
+    ^replaceVisual: oldFragment visual with: visual
 )
 ) : (
 )
 class TextStringFragment onText: t <Text> = TextFragment onText: t (
 (*A formatted string.*)
 ) (
-public createVisual = (
+public createVisual ^ <Visual> = (
 	| span = document createElement: 'span'. |
     span at: 'id' put: 'TextStringFragment'.
 	text textProperties applyTo: span.
@@ -2795,7 +2917,8 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfTextStringFragment
 )
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
-  ^replaceVisual: oldFragment visual with: visual (* optimize later? Does it even matter? *)
+    (* optimize later? Does it even matter? *)
+    ^replaceVisual: oldFragment visual with: visual
 )
 ) : (
 public forString: s <String> ^ <Instance> = (
@@ -2828,23 +2951,23 @@ public collapse = (
 	isExpanded:: false.
 	installCollapsedPresenter
 )
-createVisual = (
+createVisual ^ <Visual> = (
 	| 
-    toggleDiv <Alien[Div]> = document createElement: 'div'.
-    div <Alien[Div]> = document createElement: 'div'.
+    toggleContainer <Alien[Div]> = document createElement: 'div'.
+    composer <Alien[Div]> = document createElement: 'div'.
     |
 
 	contentHolder:: document createElement: 'div'.
     contentHolder at: 'id' put: 'ToggleComposerContentHolder'.    
 	toggleWidget:: document createElement: 'img'.
 	updateToggle: [:event | toggle. nil].
-	toggleDiv appendChild: toggleWidget.
+	toggleContainer appendChild: toggleWidget.
 
 	(contentHolder at: 'style')
 		at: 'flex-grow' put: 1;
 		at: 'flex-shrink' put: 1.
 
-	(toggleDiv at: 'style')
+	(toggleContainer at: 'style')
 		setProperty: 'flex-grow' to: 0;
 		setProperty: 'flex-shrink' to: 0.
 
@@ -2854,51 +2977,58 @@ createVisual = (
 		ifTrue: [installExpandedPresenter]
 		ifFalse: [installCollapsedPresenter].
 
-    div at: 'id' put: 'ToggleComposer'.
-	(div at: 'style')
+    composer at: 'id' put: 'ToggleComposer'.
+	(composer at: 'style')
 		at: 'display' put: 'flex';
 		at: 'flex-direction' put: 'row'.
 
-	div appendChild: toggleDiv.
-	div appendChild: contentHolder.
-	^div
+	composer appendChild: toggleContainer.
+	composer appendChild: contentHolder.
+
+	^composer
 )
 ensureCollapsedPresenter = (
-	collapsedPresenter isNil ifTrue:
-		[collapsedPresenter:: collapsedDefinition value.
-		collapsedPresenter parent: self].
+	collapsedPresenter isNil ifTrue: [
+        collapsedPresenter:: collapsedDefinition value.
+		collapsedPresenter parent: self
+    ].
 )
 ensureExpandedPresenter = (
-	expandedPresenter isNil ifTrue:
-		[expandedPresenter:: expandedDefinition value.
-		expandedPresenter parent: self].
+	expandedPresenter isNil ifTrue: [
+        expandedPresenter:: expandedDefinition value.
+		expandedPresenter parent: self
+    ].
 )
 public expand = (
 	isExpanded:: true.
 	installExpandedPresenter
 )
 installCollapsedPresenter = (
-      ensureCollapsedPresenter.
-	installContentVisual: collapsedPresenter visual.
+	ensureCollapsedPresenter.
+	installContent: collapsedPresenter.
 	collapsedPresenter noticeExposure.
 	toggleWidget at: 'src' put: (disclosureClosedImage at: 'src').
 	(toggleWidget at: 'style')
-		at: 'height' put: styleRowHeight.
+		at: 'height' put: styleInstance rowHeight.
 )
-installContentVisual: newVisual = (
+installContent: newFragment = (
 	contentHolder hasChildNodes
-		ifTrue:
-			[ | oldVisual = contentHolder at: 'firstChild'. |
-			contentHolder replaceChild: newVisual insteadOf: oldVisual] (* DOM API is stupid; it really replaces old with new *)
-		ifFalse: [contentHolder appendChild: newVisual].
+		ifTrue: [ 
+			(contentHolder at: 'firstChild') replaceWith: newFragment visual.
+            newFragment decorate.
+		] 
+		ifFalse: [
+			contentHolder appendChild: newFragment visual.
+            newFragment decorate.
+		].
 )
 installExpandedPresenter = (
-      ensureExpandedPresenter.
-	installContentVisual: expandedPresenter visual.
+    ensureExpandedPresenter.
+	installContent: expandedPresenter.
 	expandedPresenter noticeExposure.
 	toggleWidget at: 'src' put: (disclosureOpenImage at: 'src').
 	(toggleWidget at: 'style')
-		at: 'height' put: styleRowHeight.
+		at: 'height' put: styleInstance rowHeight.
 )
 public isKindOfToggleComposer ^ <Boolean> = (
   ^true
@@ -2917,29 +3047,27 @@ public updateToggle: toggleBlock <[Alien[Event]]> = (
 	^toggleWidget
 )
 updateVisualsFromSameKind: oldFragment <ToggleComposer> ^ <Alien[Element]> = (
-  toggleWidget:: oldFragment updateToggle: [:event | toggle. nil].
-  contentHolder:: oldFragment contentHolder.
-  contentHolder isNil ifTrue: ['nil contentHolder during update', out].
-  isExpanded:: oldFragment isExpanded.
-  oldFragment expandedPresenter isNil ifFalse: [
-	ensureExpandedPresenter.
-	expandedPresenter updateVisualsFrom: oldFragment expandedPresenter
+	toggleWidget:: oldFragment updateToggle: [:event | toggle. nil].
+	contentHolder:: oldFragment contentHolder.
+	contentHolder isNil ifTrue: ['nil contentHolder during update', out].
+	isExpanded:: oldFragment isExpanded.
+	oldFragment expandedPresenter isNil ifFalse: [
+		ensureExpandedPresenter.
+		expandedPresenter updateVisualsFrom: oldFragment expandedPresenter.
 	].
-  oldFragment collapsedPresenter isNil ifFalse: [
-	ensureCollapsedPresenter.
-	collapsedPresenter updateVisualsFrom: oldFragment collapsedPresenter
+	oldFragment collapsedPresenter isNil ifFalse: [
+		ensureCollapsedPresenter.
+		collapsedPresenter updateVisualsFrom: oldFragment collapsedPresenter.
 	].
-  isExpanded
-    ifTrue: [installExpandedPresenter]
-    ifFalse: [installCollapsedPresenter].
-  ^oldFragment visual
+	isExpanded
+		ifTrue: [installExpandedPresenter]
+		ifFalse: [installCollapsedPresenter].
+	^oldFragment visual
 )
 ) : (
 )
 class ToggledListFragment ofToggles: ts <Sequence[ToggleComposer]> = Fragment  (
-(* 
-A column of toggle composers that we can intelligently update.
-*)
+(* A column of toggle composers that we can intelligently update.*)
 |
 	public toggles <Sequence[ToggleComposer]> = ts.
 |
@@ -2953,10 +3081,10 @@ createVisual ^ <Visual> = (
   ^col visual
 )
 public isKindOfToggledListFragment ^ <Boolean> = (
-  ^true
+    ^true
 )
 isMyKind: f <Fragment> ^ <Boolean> = (
-  ^f isKindOfToggledListFragment
+    ^f isKindOfToggledListFragment
 )
 updateVisualsFromSameKind: oldFragment <Self> ^ <Alien[Element]> = (
 (* In a toggled list, we can either patch the old one to include new things, drop deleted ones and update the contents of existing ones
@@ -2983,8 +3111,8 @@ public class ZebraDecorator firstColor: color1 secondColor: color2 = Decorator (
 	secondColor ::= color2.
 	sequenceDefinition
 |) (
-public decorate: aVisual = (
-| odd <Boolean> ::= false.  children = (aVisual at: 'children'). |
+public apply: aVisual = (
+    | odd <Boolean> ::= false.  children = (aVisual at: 'children'). |	
 	0 to: (children at: 'length') - 1 do:
 		[:index | | each = children item: index. c <Color> |
 		c:: odd ifTrue: [firstColor] ifFalse: [secondColor].
@@ -2992,14 +3120,13 @@ public decorate: aVisual = (
 		c applyToStyle: (each at: 'style').
 		odd:: odd not.
 		].
-	^aVisual
 )
 ) : (
 public darkerColorFirst = (
-	^self firstColor: styleZebraSecondaryColor secondColor: styleZebraPrimaryColor
+	^self firstColor: styleInstance zebraSecondaryColor secondColor: styleInstance zebraPrimaryColor
 )
 public lighterColorFirst = (
-	^self firstColor: styleZebraPrimaryColor secondColor: styleZebraSecondaryColor
+	^self firstColor: styleInstance zebraPrimaryColor secondColor: styleInstance zebraSecondaryColor
 )
 )
 class DownwardRequestDispatcher sender: s = RequestDispatcher sender: s (
@@ -3120,14 +3247,14 @@ public Window ^ <HopscotchWindow class> = (
 computeContentForMenu: menuSupplier <[Menu]> ^ <Alien[Div]> = (
     |  dropDownContent = document createElement: 'div'. |
     (dropDownContent at: 'style')
-        at: 'backgroundColor' put: styleMenuBackgroundColor;
+        at: 'backgroundColor' put: styleInstance menuBackgroundColor;
         at: 'position' put: 'absolute';
         at: 'z-index' put: 10;
         at: 'padding-top' put: '8px';
         at: 'padding-bottom' put: '8px';
-        at: 'border' put: styleMenuBorderColor, ' solid 1px';
-        at: 'border-radius' put: styleDefaultRadius;
-        at: 'box-shadow' put: '0px 0px 15px ', styleMenuShadowColor;
+        at: 'border' put: styleInstance menuBorderColor, ' solid 1px';
+        at: 'border-radius' put: styleInstance defaultRadius;
+        at: 'box-shadow' put: '0px 0px 15px ', styleInstance menuShadowColor;
 		at: 'display' put: 'inline-block';
         at: 'outline' put: 0;
         at: 'cursor' put: 'default'.
@@ -3172,22 +3299,22 @@ contentFor: menuItem < MenuItem | Symbol> within: dropDownContent ^ <Alien[Eleme
 		separator:: document createElement: 'hr'.		
 		(separator at: 'style')
 			at: 'height' put: '1px';
-			at: 'background-color' put: styleBorderColor;
+			at: 'background-color' put: styleInstance borderColor;
 			at: 'border' put: 'none';
-			at: 'margin-left' put: styleMenuInset;
-			at: 'margin-right' put: styleMenuInset.
+			at: 'margin-left' put: styleInstance menuInset;
+			at: 'margin-right' put: styleInstance menuInset.
 		^separator
 	].
 	entry:: document createElement: 'div'.
 	entry at: 'textContent' put: menuItem first.
 	(entry at: 'style')
-		at: 'color' put: styleDefaultInterfaceTextColor;
-		at: 'font-family' put: styleFontFamilySansSerif;
-		at: 'font-size' put: styleFontSizeMenu;
-		at: 'padding-left' put: styleMenuInset;
-		at: 'padding-right' put: styleMenuInset;
-		at: 'height' put: styleMenuItemHeight;
-		at: 'line-height' put: styleMenuItemHeight;
+		at: 'color' put: styleInstance defaultInterfaceTextColor;
+		at: 'font-family' put: styleInstance fontFamilySansSerif;
+		at: 'font-size' put: styleInstance fontSizeMenu;
+		at: 'padding-left' put: styleInstance menuInset;
+		at: 'padding-right' put: styleInstance menuInset;
+		at: 'height' put: styleInstance menuItemHeight;
+		at: 'line-height' put: styleInstance menuItemHeight;
 		at: 'white-space' put: 'nowrap'.
    entry
 		addEventListener: 'mouseover' action:


### PR DESCRIPTION
The Style class contains values used to modify the visual presentation of various widgets. A style cache is populated with pre-constructed style dictionaries to reduce the number of calls to Javascript set/get when creating widgets.

Styling is applied in decorate. The setting of visual state had leaked out of decorate and moved into createVisual. I think it was the indentation of the library architect to defer styling until decorate is called, and this is now the case.

Performance is slightly better, but this isn't a huge performance win. The separation of creation and styling is a good thing though.

I have tracked down as many bugs as I could find, although there may be lurkers.