### PR TITLE
Improve insertion of widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 workspace.code-workspace
 out
+buildlocal.sh

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -2822,14 +2822,28 @@ evaluateResponse ^ <[:CodeMirrorFragment]> = (
 public respondToMakeButton = (
         | src <String> ::=  cm editor getSelection. |
         src isEmpty ifTrue: [
-            src:: cm currentLine.
+            |
+            line = cm currentLine.
+            lineNumber = cm currentLineNumber.
+            start = JSObject new.
+            end = JSObject new.
+            |            
+            src:: line.
+            start 
+                at: 'line' put: lineNumber;
+                at: 'ch' put: 0.
+            end 
+                at: 'line' put: lineNumber;
+                at: 'ch' put: src size.
+                
+            cm editor setSelection: start end: end.
         ].
         src isEmpty ifFalse: [
             | 
             button <ButtonFragment> = button: src action: [ 
                updateGUI: [subject evaluate: (withoutNbsp: src)]].
             |
-            cm insert: button atLine: cm currentLineNumber andColumn: cm currentColumnNumber.         
+            cm replace: button.         
             cm editor focus.
         ].
 )

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -584,6 +584,19 @@ public insert: fragment<Fragment> atLine: line<Integer> andColumn: column <Integ
         at: 'clearWhenEmpty' put: false.
     editor markText: position end: position replacedWith: replaced.
 )
+public replace: withFragment<Fragment> = (
+    |
+    start = editor getCursor: 'from'.
+    end = editor getCursor: 'to'.
+	replaced = JSObject new.
+	visual = withFragment visual.
+    |
+    replaced 
+        at: 'replacedWith' put: visual;
+        at: 'clearWhenEmpty' put: false.
+    editor markText: start end: end replacedWith: replaced.
+    editor setCursor: end.
+)
 public currentLineNumber ^ <Integer> = (
   ^editor getCursor at: #line
 )

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -579,10 +579,12 @@ public insert: fragment<Fragment> atLine: line<Integer> andColumn: column <Integ
 	replaced = JSObject new.
 	visual = fragment visual.
     |
-	position at: 'line' put: line.
-	position at: 'ch' put: column.
-    replaced at: 'replacedWith' put: visual.
-    replaced at: 'clearWhenEmpty' put: false.
+	position 
+        at: 'line' put: line;
+        at: 'ch' put: column.
+    replaced 
+        at: 'replacedWith' put: visual;
+        at: 'clearWhenEmpty' put: false.
     editor markText: position end: position replacedWith: replaced.
 )
 ) : (


### PR DESCRIPTION
The InspectIt button command now does the following:

If there is no selection, the entire text of the line with the insertion point is replaced with a button.
If there is a selection, the selected text is replaced with a button.

This action is not undoable. There may be a way to get CodeMirror to know that an edit has occurred. If you undo the InspectIt command, the button and the previous text vanish.

I am to move the cursor around, delete and text before and after button(s) with the expected behavior.

It might be nice to have the InspectIt menu item present a dialog, where you can set the button title. I can look into doing that.