### PR TITLE
Add declarative event handlers; begin work on more declarative widgets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,3 @@
 workspace.code-workspace
 out
 buildlocal.sh
-<<<<<<< HEAD
-
-=======
->>>>>>> gene/gestures

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 workspace.code-workspace
 out
 buildlocal.sh
+<<<<<<< HEAD
 
+=======
+>>>>>>> gene/gestures

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -252,7 +252,8 @@ future_deployAction = (
 )
 class ClassEntryPresenter onSubject: s <ClassSubject> = EntryPresenter onSubject: s () (
 accessIndicator = (
-	^image: (iconForAccessModifier: subject accessModifier) size: styleButtonSize.
+	^(image: (iconForAccessModifier: subject accessModifier))
+        height: styleButtonSize.
 )
 classCommentSummary ^ <String> = (
 	|
@@ -274,7 +275,8 @@ public tag ^ <String> = (
 collapsedDefinition = (
 	^row1: {
         defaultBlank.
-		image: ide images classIcon size: styleButtonSize.
+		(image: ide images classIcon)
+            height: styleButtonSize.
         defaultBlank.
 		accessIndicator.
         defaultBlank.
@@ -328,7 +330,8 @@ expandedDefinition = (
 headerDefinition ^ <Fragment> = (
   ^row: {
       defaultBlank.
-      image: (iconForAccessModifier: subject accessModifier) size: styleButtonSize.
+      (image: (iconForAccessModifier: subject accessModifier))
+        height: styleButtonSize.
       defaultBlank.
       (link: subject name action: [toggle toggle]) color: actionLinkColor.
 	showClassName
@@ -368,7 +371,8 @@ slotList ^ <Fragment> = (
 					(column: (sl collect: [:ea | 
 						row: {
                             defaultBlank.
-							image: (iconForAccessModifier: ea accessModifier) size: styleButtonSize. 
+							(image: (iconForAccessModifier: ea accessModifier))
+                                height: styleButtonSize. 
                             defaultBlank.
 							label: ea name.
 						}
@@ -487,7 +491,8 @@ class ClassPresenter onSubject: s = ProgrammingPresenter onSubject: s (
   |
 ) (
 accessIndicator = (
-	^image: (iconForAccessModifier: subject accessModifier) size: styleButtonSize.
+	^(image: (iconForAccessModifier: subject accessModifier))
+        height: styleButtonSize.
 )
 changeResponse ^ <[:CodeMirrorFragment :Event]> = (
 	^[:ed <CodeMirrorFragment> :event <Event>  |
@@ -569,7 +574,8 @@ minorClassHeadingColor = (
 nestedClass: cdm = (
 	^collapsed: [row: {
                     defaultBlank.
-					image: (iconForAccessModifier: cdm accessModifier) size: styleButtonSize.
+					(image: (iconForAccessModifier: cdm accessModifier))
+                        height: styleButtonSize.
 					defaultBlank.
 					link: cdm simpleName action: [enterSubject:: ClassSubject onModel: cdm]
 					}
@@ -633,7 +639,8 @@ classNameAndHierarchySummary = (
 	^column: {
 		row: {
 			smallBlank.
-			image: ide images classIcon size: styleButtonSize.
+			(image: ide images classIcon)
+                 height: styleButtonSize.
 			smallBlank.
 			row: parts.
 			filler.
@@ -1126,7 +1133,8 @@ textAndActionWisdom: wisdom = (
 )
 textAndImageWisdom: wisdom = (
 	^row: {
-		image: wisdom image size: styleButtonSize.
+		(image: wisdom image)
+           height: styleButtonSize.
 		mediumBlank.
 		elastic:
 			(textDisplay: wisdom text).
@@ -1494,7 +1502,8 @@ public definition ^ <Fragment> = (
 	| toggle |
 	toggle::
 		collapsed: [row: {
-			image: (iconForAccessModifier: subject accessModifier) size: styleButtonSize.
+			(image: (iconForAccessModifier: subject accessModifier))
+                height: styleButtonSize.
 			defaultBlank.
 			(link: subject name action: [toggle expand]) color: actionLinkColor.
 		      nestingInfo.
@@ -1511,7 +1520,8 @@ public definition ^ <Fragment> = (
 			colorizeMethodSource: src withEditor: cm.
 			column: {
 			row: {
-			  image: (iconForAccessModifier: subject accessModifier) size: styleButtonSize.
+			  (image: (iconForAccessModifier: subject accessModifier))
+                height: styleButtonSize.
 			  defaultBlank.
 			  (link: subject name action: [toggle collapse]) color: actionLinkColor.
 				nestingInfo.
@@ -1538,8 +1548,10 @@ acceptResponse ^ <[:CodeMirrorFragment :Event]> = (
 		]
 )
 referencesMenuMessageItems = (
-	| items sortedMessages|
-	items:: List new.
+	| 
+    items = List new.
+    sortedMessages
+    |
 	sortedMessages:: subject messages sort: [:m1 :m2 | 
        lexicallyLessOrEqual: m1 than: m2
      ].
@@ -1550,7 +1562,7 @@ referencesMenuMessageItems = (
 				{selector. [browseSelector: selector]}]].
 	^items
 )
-) : (
+) : ( 
 )
 public class MethodSubject onModel: mm <MethodMirror> = Subject onModel: mm (
 (* Manages the UI for a method. *)
@@ -1680,7 +1692,8 @@ class NamespaceEntryPresenter onSubject: s = EntryPresenter onSubject: s () (
 collapsedDefinition = (
 	^row1: {
         defaultBlank.
-		image: ide images classPresenterIcon size: styleButtonSize.
+		(image: ide images classPresenterIcon)
+            height: styleButtonSize.
 		defaultBlank.
 		row: {link: subject key action: [
 			(*ide defaultPopularityRecord
@@ -1711,7 +1724,8 @@ class ValueEntryPresenter onSubject: s = EntryPresenter onSubject: s (|
 collapsedDefinition = (
 	^row1: {
         defaultBlank.
-		image: ide images classUnknownIcon size: styleButtonSize.
+		(image: ide images classUnknownIcon)
+            height: styleButtonSize.
 		defaultBlank.
 		link: key action: [enterSubject:: subject].
 	} row2: {
@@ -2396,7 +2410,8 @@ actionLinkColor = (
 	^Color black
 )
 addButtonWithAction: aBlock = (
-	^imageButton: ide images addImage action: aBlock size: styleButtonSize
+	^(imageButton: ide images addImage action: aBlock)
+        height: styleButtonSize
 )
 addButtonWithMenu: menu = (
 	^dropDownMenu: menu image: ide images addImage
@@ -2408,10 +2423,12 @@ browseSelector: selector = (
 	enterSubject: (SelectorSubject onModel: selector)
 )
 collapseButtonWithAction: aBlock = (
-	^imageButton: ide images collapseImage action: aBlock size: styleButtonSize
+	^(imageButton: ide images collapseImage action: aBlock)
+        height: styleButtonSize
 )
 expandButtonWithAction: aBlock = (
-	^imageButton: ide images expandImage action: aBlock size: styleButtonSize
+	^(imageButton: ide images expandImage action: aBlock)
+        height: styleButtonSize
 )
 iconForAccessModifier: am = (
 	#private = am ifTrue: [^ide images privateAccessImage].
@@ -2435,10 +2452,12 @@ inspectObjectMirror: object <ObjectMirror> = (
 	enterSubject:: ObjectSubject onModel: object.
 )
 itemReferencesButtonWithAction: aBlock = (
-	^imageButton: ide images itemReferencesImage action: aBlock size: styleButtonSize
+	^(imageButton: ide images itemReferencesImage action: aBlock)
+        height: styleButtonSize
 )
 saveButtonWithAction: aBlock = (
-	^imageButton: ide images downloadImage action: aBlock size: styleButtonSize
+	^(imageButton: ide images downloadImage action: aBlock)
+        height: styleButtonSize
 )
 defaultBlank = (
 	^blank: 3
@@ -2472,7 +2491,8 @@ objectSubjectForMirror: objectMirror <ObjectMirror> = (
 	^ObjectSubject onModel: objectMirror
 )
 refreshButton = (
-	^imageButton: ide images refreshImage action: [shell refresh] size: styleButtonSize
+	^(imageButton: ide images refreshImage action: [shell refresh])
+        height: styleButtonSize
 )
 respondToInspectPresenter = (
 	inspectObject: self.
@@ -2492,7 +2512,8 @@ linkToBrowseSelector: selector = (
 linkToBrowseNamespace: ns key: key = (
 	^row: {
         defaultBlank.
-		image: ide images classPresenterIcon size: styleButtonSize.
+		(image: ide images classPresenterIcon)
+            height: styleButtonSize.
 		defaultBlank.
 		link: key
 		action: [enterSubject:: NamespaceSubject onModel: ns key: key]}.
@@ -2508,14 +2529,14 @@ browseClass: klass <Behavior | ClassDeclarationMirror> = (
 	enterSubject:: ClassSubject onModel: decl.
 )
 helpButton = (
-	^imageButton: ide images helpImage 
-				  action: [updateGUI: [subject helpActive: true]] 
-				  size: styleButtonSize
+	^(imageButton: ide images helpImage  action: [
+        updateGUI: [subject helpActive: true]])
+        height: styleButtonSize
 )
 closeHelpButton = (
-	 ^imageButton: ide images clearImage 
-	 			   action: [updateGUI: [subject helpActive: false]] 
-	  			   size: styleButtonSize
+	 ^(imageButton: ide images clearImage 
+	 			   action: [updateGUI: [subject helpActive: false]])
+	  			   height: styleButtonSize
 )
 helpText ^ <Fragment> = (
   ^textDisplay: 'No help text defined for this presenter. Sorry.'
@@ -2761,9 +2782,9 @@ changeResponse = (
   ^subject isLive ifTrue: [liveChangeResponse] ifFalse: [deadChangeResponse]
 )
 clearResultsButton ^ <Fragment> = (
-    ^imageButton: ide images clearImage 
-            action: [updateGUI: [subject clear]] 
-            size: styleButtonSize
+    ^(imageButton: ide images clearImage 
+            action: [updateGUI: [subject clear]]) 
+            height: styleButtonSize
 )
 results ^ <List[Fragment]> = (
     ^subject results collect: [:r | 
@@ -3142,7 +3163,8 @@ searchField ^ <Fragment> = (
     ^textView
 )
 saveAll = (
-    ^imageButton: ide images saveImage action: [saveSources] size: styleButtonSize
+    ^(imageButton: ide images saveImage action: [saveSources]) 
+        height: styleButtonSize
 )
 toolbarItems ^ <Array[Fragment]>  = (
  ^super toolbarItems, {saveAll. smallBlank. searchField}
@@ -3183,7 +3205,8 @@ isMyKind: other ^ <Boolean> = (
   ^other isKindOfImageView
 )
 public definition ^ <Fragment> = (
-  ^image: subject model reflectee size: styleButtonSize
+    ^(image: subject model reflectee) 
+        height: styleButtonSize
 )
 ) : (
 )

--- a/GraphicsForHTML5.ns
+++ b/GraphicsForHTML5.ns
@@ -43,6 +43,9 @@ public asCSSString = (
 	^'rgba(', red printString, ',', green printString, ',', blue printString, ',', alpha printString, ')'
 )
 ) : (
+public red: brightness = (
+	^self scaledR: brightness g: 0 b: 0 a: 255
+)
 public black = (
 	^self scaledR: 0 g: 0 b: 0 a: 255
 )
@@ -57,6 +60,9 @@ public gray = (
 )
 public gray: brightness = (
 	^self r: brightness g: brightness b: brightness
+)
+public green = (
+	^self r: 0.0 g: 1.0 b: 0.0
 )
 public h: hue s: saturation v: brightness = (
 	| s v hf i f p q t |
@@ -98,13 +104,13 @@ public r: r g: g b: b a: a = (
 	^self scaledR: (r * 255) floor g: (g * 255) floor b: (b * 255) floor a: a
 )
 public red = (
-	^self scaledR: 255 g: 0 b: 0 a: 255
+    ^self r: 1.0 g: 0.0 b: 0.0
 )
-public red: brightness = (
-	^self scaledR: brightness g: 0 b: 0 a: 255
+public yellow = (
+    ^self r: 1.0 g: 1.0 b: 0.0
 )
 public white = (
-	^self scaledR: 255 g: 255 b: 255 a: 255
+    ^self r: 1.0 g: 1.0 b: 1.0
 )
 )
 public class Context on: a = (|

--- a/HelloDOM.ns
+++ b/HelloDOM.ns
@@ -24,10 +24,10 @@ public main: platform args: args = (
 			yourself).
 
 	(body at: 'style')
-		at: 'borderStyle' put: 'solid';
-		at: 'borderWidth' put: '20px';
-		at: 'borderRadius' put: '25px';
-		at: 'borderColor' put: 'black';
+		at: 'border-style' put: 'solid';
+		at: 'border-width' put: '20px';
+		at: 'border-radius' put: '25px';
+		at: 'border-color' put: 'black';
 		at: 'padding' put: '10px'.
 )
 ) : (

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -230,9 +230,6 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
         at: 'oninput' put: [:event | 
             action value: (Float parse: (slider at: 'value')).
         ].
-
-   oldVisual at: 'onclick' put: [:event | action value. false];
-		 at: 'disabled' put: enabled not.
    ^oldVisual
 )
 ) : (
@@ -1712,6 +1709,8 @@ applyStyle: element <Alien[HTMLElement]> = (
         (element at: 'style')
             at: 'width' put: widthStyle;
             at: 'height' put: heightStyle;
+            at: 'max-width' put: widthStyle;
+            at: 'max-height' put: heightStyle;
             at: 'background-color' put: (style backgroundColor) asCSSString;
             at: 'color' put: (style foregroundColor) asCSSString;
             at: 'border' put: 'none';

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -163,17 +163,75 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 )
 ) : (
 )
-class ButtonFragment label: l action: a = LeafFragment (|
-	public label = l.
-	action = a.
-	public enabled ::= true.
-|) (
+class RectangleFragment = BlankFragment (
+    style backgroundColor: Color black.
+) (
 createVisual = (
-	^(document createElement: 'button')
-		appendChild: (document createTextNode: label);
+    | rectangle = super createVisual. |
+    applyStyle: rectangle.
+
+    (rectangle at: 'style')
+        at: 'cursor' put: 'default'.
+        
+    registerGestures: rectangle.
+    
+    ^rectangle.
+)
+public isKindOfRectangleFragment ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfRectangleFragment
+)
+updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
+  ^oldFragment visual
+)
+public fill: color <Color> = (
+    style backgroundColor: color.
+)
+) : (
+)
+class Style = (
+    |
+    public backgroundColor <Color> ::= Color white.
+    public foregroundColor <Color> ::= Color black.
+
+    public borderType <String> ::= 'none'.
+    public borderColor <Color> ::= Color white.
+    public borderStyle <String> ::= 'solid'.
+    public borderWidth <Float> ::= 0.
+
+    public cornerRadius <Float> ::= 0.
+    |
+) (
+)
+class ButtonStyle = Style(
+    backgroundColor:: Color gray: 0.97.
+    foregroundColor:: Color gray: 0.17.
+    cornerRadius:: 5.
+) (
+)
+class ButtonFragment label: l action: a = LeafFragment (
+    |
+	public label = l.
+    public enabled ::= true.
+	action = a.
+    style <ButtonStyle> = ButtonStyle new.
+    |
+) (
+createVisual = (
+    |
+    button = document createElement: 'button'.
+    |
+    button
+        appendChild: (document createTextNode: label);
 		at: 'onclick' put: [:event | action value. false];
 		at: 'disabled' put: enabled not;
-		yourself
+		yourself.
+
+    applyStyle: button.
+
+    ^button
 )
 public isKindOfButtonFragment ^ <Boolean> = (
 	^true
@@ -241,7 +299,6 @@ updateVisualsFromSameKind: oldFragment <CanvasFragment>  ^ <Alien[Canvas]>  = (
 ) : (
 )
 public class CodeMirrorFragment onText: t <String> = LeafFragment (
-(* An experiment to see how to integrate CodeMirror as editor. *)
 |
     public editor <Alien[CodeMirror]>
 	textSlot <TextFragment | String> ::= t.
@@ -400,9 +457,9 @@ createVisual = (
 		at: 'min-height' put: styleTextInputHeight;
 		at: 'background-color' put: 'white';
 		at: 'opacity' put: 1.0;
-		at: 'borderStyle' put: 'solid';
-		at: 'borderWidth' put: '1px';
-		at: 'borderColor' put: styleBorderColor.
+		at: 'border-style' put: 'solid';
+		at: 'border-width' put: '1px';
+		at: 'border-color' put: styleBorderColor.
 
 	useEditControls ifTrue: [
 		counterfactualBar:: document createElement: 'div'.
@@ -906,7 +963,7 @@ Another subclass responsibility is #updateVisualsFromSameKind:, which updates th
 (presumably older) fragment of the same kind.
 
 *)
-      |
+    |
 	visualX
 	public parent
 	public size ::= nil.
@@ -1401,11 +1458,13 @@ public openSubject: s = (
 	^into: body openSubject: s
 )
 )
-class HyperlinkFragment label: l action: a = LeafFragment (|
+class HyperlinkFragment label: l action: a = LeafFragment (
+    |
 	public label = l.
 	action = a.
 	public color ::= Color r: 0 g: 0 b: 1.
-|) (
+    |
+) (
 createVisual = (
 	| 
     container = document createElement: 'div'.
@@ -1422,13 +1481,13 @@ createVisual = (
 
     anchor at: 'id' put: 'HyperlinkFragment'.
 	anchor at: 'href' put: '#'.
+    anchor at: 'onclick' put: [:event | action value. false].
 	anchor appendChild: (document createTextNode: label).
-	anchor at: 'onclick' put: [:event | action value. false].
 	(anchor at: 'style')
 		at: 'textDecoration' put: 'none'; (* No underline *)
 		at: 'overflow' put: 'hidden';
         at: 'white-space' put: 'nowrap'.
-
+        
     anchor
         addEventListener: 'mouseover' action:
             [:event | (anchor at: 'style') at: 'textDecoration' put: 'underline'. nil];
@@ -1543,7 +1602,39 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 )
 ) : (
 )
-class LeafFragment = Fragment () (
+(* 
+A LeafFragment fragment has no children.
+
+Event listeners can be added as closures to respond to events.
+
+How these various handlers are implemented is a design decision of classes that
+derive from LeafFragment.
+
+Each subclass should support every event handler when appropriate.
+*)
+class LeafFragment = Fragment (
+    |        
+    public onClick <[:event]> ::= [:event | ].
+    public onMouseDown <[:event]> ::= [:event | ].
+    public onMouseEnter <[:event]> ::= [:event | ].
+    public onMouseMove <[:event]> ::= [:event | ].
+    public onMouseOver <[:event]> ::= [:event | ].
+    public onMouseOut <[:event]> ::= [:event | ].
+    public onMouseUp <[:event]> ::= [:event | ].
+    public onTouchStart <[:event]> ::= [:event | ].
+    public onTouchMove <[:event]> ::= [:event | ].
+    public onTouchEnd <[:event]> ::= [:event | ].
+    public onTouchCancel <[:event]> ::= [:event | ].
+    public onWheel <[:event]> ::= [:event | ].
+
+    width <Float> ::= -1.
+    height <Float> ::= -1.
+    widthStyle <String> ::= 'auto'.
+    heightStyle <String> ::= 'auto'.
+
+    style = Style new.
+    |    
+) (
 public childrenDo: aBlock = (
 	(* No children. *)
 )
@@ -1551,6 +1642,64 @@ public hasPendingChanges ^<Boolean> = (
     (* For simplicity, we assume that most leaf fragments can never have pending changes. Those for which it is not true should override this method. *)
     ^false
 )
+public border: color <Color> = (
+    border: color width: 1.0.
+)
+public border: color <Color> width: w <Float> = (
+    style borderColor: color.
+    style borderWidth: w.
+
+    w ~= 0 ifTrue: [
+        style borderType: 'solid'.
+    ].
+)
+public frame: width <Float> height: h <Float> = (
+    width:: width.
+    height:: h.
+)
+applyStyle: element <Alien[HTMLElement]> = (
+    nil = style ifFalse: [
+
+        width = -1 ifFalse: [ widthStyle:: width printString, 'px' ].
+        height = -1 ifFalse: [ heightStyle:: height printString, 'px' ].
+
+        (element at: 'style')
+            at: 'width' put: widthStyle;
+            at: 'height' put: heightStyle;
+            at: 'background-color' put: (style backgroundColor) asCSSString;
+            at: 'color' put: (style foregroundColor) asCSSString;
+            at: 'border' put: 'none';
+            at: 'border-radius' put: style cornerRadius asString, 'px'.
+
+        'none' = (style borderType) ifFalse: [
+            (element at: 'style')
+                at: 'border' put: (style borderType);
+                at: 'border-color' put: (style borderColor) asCSSString;
+                at: 'border-width' put: (style borderWidth) printString, 'px';
+                at: 'border-style' put: (style borderStyle).
+        ].            
+    ].           
+)
+(* 
+Register gesture handlers on an element. This is a convenience method for classes
+that have a single point of interaction. Classes composed of multiple elements
+may need a more granular registration mechanism.
+*)
+registerGestures: element <Alien[HTMLElement]> = (
+    element  
+        at: 'onclick' put: [:event | onClick value: event. false];
+        at: 'onmousedown' put: [:event | onMouseDown value: event. false];
+        at: 'onmouseenter' put: [:event | onMouseEnter value: event. false];
+        at: 'onmousemove' put: [:event | onMouseMove value: event. false];
+        at: 'onmouseout' put: [:event | onMouseOut value: event. false];
+        at: 'onmouseover' put: [:event | onMouseOver value: event. false];
+        at: 'onmouseup' put: [:event | onMouseUp value: event. false];
+        at: 'ontouchstart' put: [:event | onTouchStart value: event. false];
+        at: 'ontouchmove' put: [:event | onTouchMove value: event. false];
+        at: 'ontouchend' put: [:event | onTouchEnd value: event. false];
+        at: 'ontouchcancel' put: [:event | onTouchCancel value: event. false];
+        at: 'onwheel' put: [:event | onWheel value: event. false].
+)        
 ) : (
 )
 class MultiPageNavigationHistory = NavigationHistory (
@@ -1929,7 +2078,7 @@ public = anotherPresenter = (
 alert: text = (
 	window alert: text
 )
-prompt: title input: i <String> ^ <String> = (
+prompt: title <String> input: i <String> ^ <String> = (
 	^window prompt: title input: i.
 )
 blank: size = (
@@ -1940,6 +2089,9 @@ button: label <String> action: block <[]> = (
 )
 canvas: extent <Point> = (
 	^CanvasFragment withExtent: extent
+)
+rectangle = (
+	^RectangleFragment new
 )
 public childrenDo: aBlock = (
 	nil = substanceSlot ifFalse: [aBlock value: substanceSlot]
@@ -2047,12 +2199,6 @@ image: image <Image> = (
 	fragment:: StaticImageFragment image: image.
 	^fragment 
 )
-image: image <Image> size: s <Float> = (
-	| fragment <StaticImageFragment> |
-	fragment:: StaticImageFragment image: image.
-    fragment height: s.
-	^fragment 
-)
 imageButton: image <Image> action: block <[]> = (
 	^ImageButtonFragment new
         image: image;
@@ -2106,9 +2252,6 @@ public listElementMetapresenter ^<Presenter> = (
         filler compressibility: 0.
         (deferred: [extraInformationMetapresenter]) compressibility: 1.
     }
-)
-mediumBlank = (
-	^blank: 10
 )
 minimalMetapresenter ^<Presenter> = (
 (* A minimal presenter that can represent the receiver in places such as the History. *)
@@ -2223,6 +2366,9 @@ creatingWindowCompatibleWith: p <Presenter> ^ <Boolean> = (
 )
 smallBlank = (
 	^blank: 5
+)
+mediumBlank = (
+	^blank: 10
 )
 html: h <String> = (
   ^HTMLFragment html: h
@@ -2408,13 +2554,15 @@ public registerNewPresenter: newPresenter <Presenter>  = (
 )
 ) : (
 )
-class StaticImageFragment image: i = LeafFragment (|
+class StaticImageFragment image: i = LeafFragment (
+    |
 	public image = i.
     public width <Float> ::= -1.
     public height <Float> ::= -1.
     widthStyle <String> ::= 'auto'.
     heightStyle <String> ::= 'auto'.
-|) (
+    |
+) (
 createVisual = (
 	| div img |
 	div:: document createElement: 'div'.
@@ -2433,6 +2581,9 @@ createVisual = (
 		at: 'height' put: heightStyle;
         at: 'object-fit' put: 'contain'.
 	div appendChild: img.
+
+    registerGestures: img.
+
 	^div
 )
 public isKindOfStaticImageFragment ^ <Boolean> = (
@@ -2466,6 +2617,7 @@ createVisual = (
 	div at: 'textContent' put: text.
 	nil = color ifFalse:
 		[(div at: 'style') setProperty: 'color' to: color asCSSString].
+
 	^div
 )
 public isKindOfStaticLabelFragment ^ <Boolean> = (
@@ -2629,10 +2781,10 @@ createVisual = (
 		|
 
         (editor at: 'style')
-			at: 'borderStyle' put: 'solid';
-			at: 'borderWidth' put: '1px';
-			at: 'borderColor' put: styleBorderColor;
-            at: 'borderRadius' put: styleDefaultRadius;
+			at: 'border-style' put: 'solid';
+			at: 'border-width' put: '1px';
+			at: 'border-color' put: styleBorderColor;
+            at: 'border-radius' put: styleDefaultRadius;
 			at: 'background-color' put: 'white'.
 
 		editor addEventListener: 'keydown' action: 
@@ -2859,8 +3011,8 @@ public forString: s <String> properties: tps <TextProperties> ^<Instance> = (
 )
 )
 class ToggleComposer collapsedDefinition: collapsed <[Fragment]>
- expandedDefinition: expanded <[Fragment]>
- initiallyExpanded: flag <Boolean> = Composer (
+    expandedDefinition: expanded <[Fragment]>
+    initiallyExpanded: flag <Boolean> = Composer (
 |
 expandedDefinition <[Fragment]> = expanded.
 collapsedDefinition <[Fragment]> = collapsed.

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -191,6 +191,52 @@ public fill: color <Color> = (
 )
 ) : (
 )
+class SliderFragment value: v <Float> min: mn <Float> max: mx <Float> action: a <[]> = LeafFragment (
+    |
+    value <Float> = v.
+    min <Float> = mn.
+    max <Float> = mx.
+    action <[]> = a.
+    |
+
+    v out.
+) (
+createVisual = (
+    | 
+    slider = document createElement: 'input'. 
+    |
+
+    slider
+        at: 'type' put: 'range';
+        at: 'value' put: value;
+        at: 'min' put: min;
+        at: 'max' put: max;
+        at: 'oninput' put: [:event | 
+            action value: (Float parse: (slider at: 'value')).
+        ].
+    
+    ^slider.
+)
+public isKindOfSliderFragment ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfSliderFragment
+)
+updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
+    | oldVisual = oldFragment visual.|
+    
+    oldVisual
+        at: 'oninput' put: [:event | 
+            action value: (Float parse: (slider at: 'value')).
+        ].
+
+   oldVisual at: 'onclick' put: [:event | action value. false];
+		 at: 'disabled' put: enabled not.
+   ^oldVisual
+)
+) : (
+)
 class Style = (
     |
     public backgroundColor <Color> ::= Color white.
@@ -240,12 +286,13 @@ isMyKind: f <Fragment> ^ <Boolean> = (
   ^f isKindOfButtonFragment
 )
 updateVisualsFromSameKind: oldFragment <ButtonFragment>  ^ <Alien[ButtonElement]> = (
-| oldVisual = oldFragment visual.|
-   oldVisual at: 'onclick' put: [:event | action value. false];
-		 at: 'disabled' put: enabled not.
-   oldFragment label ~= label ifTrue: [
-	oldVisual replaceChild: (document createTextNode: label) oldChild: (oldVisual at:  'firstChild')
-	].
+    | oldVisual = oldFragment visual.|
+    oldVisual 
+        at: 'onclick' put: [:event | action value. false];
+        at: 'disabled' put: enabled not.
+    oldFragment label ~= label ifTrue: [
+        oldVisual replaceChild: (document createTextNode: label) oldChild: (oldVisual at:  'firstChild')
+    ].
    ^oldVisual
 )
 ) : (
@@ -1030,7 +1077,7 @@ public shell = (
 		ifFalse: [parent shell]
 )
 updateGUI: action <[Object]> = (
-(* Must be called whenever a semantic change (a change to either the underlying model,  or the subject state).
+(* Must be called whenever a semantic change (a change to either the underlying model, or the subject state).
     The action parameter is a closure that will cause the desired semantic change.  
 *)
   updateAllWindows: action.
@@ -1105,7 +1152,7 @@ definition = (
 				}).
 		blank: 2.
 		zebra: (column: presentersForHistoryEntries).
-		}
+	}
 )
 forgetAll = (
 	shell eraseHistory
@@ -1160,8 +1207,7 @@ public createPresenter = (
 )
 public historyDo: aBlock = (
 (* Evaluate the argument for all presenters in the history I represent, most recently visited one first. *)
-
-^model allVisits reverse do: aBlock
+    ^model allVisits reverse do: aBlock
 )
 public isKindOfHistorySubject ^ <Boolean> = (
   ^true
@@ -1649,7 +1695,7 @@ public border: color <Color> width: w <Float> = (
     style borderColor: color.
     style borderWidth: w.
 
-    w ~= 0 ifTrue: [
+    w > 0 ifTrue: [
         style borderType: 'solid'.
     ].
 )
@@ -2092,6 +2138,9 @@ canvas: extent <Point> = (
 )
 rectangle = (
 	^RectangleFragment new
+)
+slider: value <Float> min: mn <Float> max: mx <Float> action: a = (
+	^SliderFragment value: value min: mn max: mx action: a
 )
 public childrenDo: aBlock = (
 	nil = substanceSlot ifFalse: [aBlock value: substanceSlot]

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -527,18 +527,6 @@ updateVisualsFromSameKind: oldFragment <CodeMirrorFragment>  ^ <Alien[CodeMirror
 public currentLine ^ <String> = (
   ^editor getLine: currentLineNumber
 )
-public insert: fragment<Fragment> atLine: line<Integer> andColumn: column<Integer> = (
-    |
-    position = JSObject new.
-	replaced = JSObject new.
-	visual = fragment visual.
-    |
-	position at: 'line' put: line.
-	position at: 'ch' put: column.
-    replaced at: 'replacedWith' put: visual.
-    replaced at: 'clearWhenEmpty' put: false.
-    editor markText: position end: position replacedWith: replaced.
-)
 public showFragment: message <Fragment> = (
 	messageContainer at: 'innerHTML' put: message.
 	visual appendChild: messageContainer.

--- a/HopscotchGestureDemo.ns
+++ b/HopscotchGestureDemo.ns
@@ -1,0 +1,91 @@
+Newspeak3
+'Samples'
+class HopscotchGestureDemo packageUsing: manifest = (
+	|
+	private hopscotchRuntime = manifest HopscotchForHTML5Runtime packageUsing: manifest.
+	|
+) (
+class Demo usingPlatform: p = (|
+	Subject = p hopscotch core Subject.
+	Presenter = p hopscotch core Presenter.
+	Color = p graphics Color.	
+|) (
+class DemoPresenter onSubject: s = Presenter onSubject: s (| counter ::= 0. |) (
+public definition = (
+	^row: {
+        (column: {
+            button: 'Gestures' action: [].
+        })
+            color: (Color gray: 0.92).
+        
+        (column: {
+            rectangle
+                fill: Color green;
+                frame: 300 height: 300;
+                border: Color yellow width: 3;
+                onClick: [:event | 
+                    'onClick' out.
+                ];
+                onMouseDown: [:event | 
+                    'onMouseDown' out.
+                ];
+                onMouseUp: [:event | 
+                    'onMouseUp' out.
+                ];
+                onMouseEnter: [:event | 
+                    'onMouseEnter' out.
+                ];
+                onMouseMove: [:event | 
+                    'onMouseMove' out.
+                ];
+                onMouseOut: [:event | 
+                    'onMouseOut' out.
+                ];
+                onWheel: [:event | 
+                    'onWheel' out.
+                ];
+                onTouchStart: [:event | 
+                    'onTouchStart' out.
+                ];
+                onTouchMove: [:event | 
+                    'onTouchMove' out.
+                ];
+                onTouchEnd: [:event | 
+                    'onTouchEnd' out.
+                ];
+                onTouchCancel: [:event | 
+                    'onTouchCancel' out.
+                ].
+        })
+            color: (Color gray: 0.5)
+    }
+)
+public isKindOfDemoPresenter ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfDemoPresenter
+)
+) : (
+)
+public class DemoSubject new = Subject onModel: nil (
+) (
+public createPresenter = (
+	^DemoPresenter onSubject: self
+)
+isMyKind: other ^ <Boolean> = (
+    ^other isKindOfDemoPresenter
+)
+) : (
+)
+) : (
+)
+public main: platform args: args = (
+	| 
+    hopscotchPlatform = hopscotchRuntime using: platform.
+    demo = Demo usingPlatform: hopscotchPlatform.
+    |
+	hopscotchPlatform hopscotch core HopscotchWindow openSubject: demo DemoSubject new.
+)
+) : (
+)

--- a/HopscotchGestureDemo.ns
+++ b/HopscotchGestureDemo.ns
@@ -29,7 +29,7 @@ public definition = (
         (column: {
             rectangle
                 fill: Color green;
-                frame: 300 height: 300;
+                frame: (300 - borderWidth) height: (300 - borderWidth);
                 border: Color yellow width: borderWidth;
                 onClick: [:event | 
                     'onClick' out.

--- a/HopscotchGestureDemo.ns
+++ b/HopscotchGestureDemo.ns
@@ -9,12 +9,20 @@ class Demo usingPlatform: p = (|
 	Subject = p hopscotch core Subject.
 	Presenter = p hopscotch core Presenter.
 	Color = p graphics Color.	
+    private borderWidth <Float> ::= 1.0. 
 |) (
-class DemoPresenter onSubject: s = Presenter onSubject: s (| counter ::= 0. |) (
+class DemoPresenter onSubject: s = Presenter onSubject: s (
+) (
 public definition = (
 	^row: {
         (column: {
             button: 'Gestures' action: [].
+            slider: borderWidth 
+                    min: 0 
+                    max: 100 
+                    action: [:value |                         
+                        updateGUI: [ borderWidth:: value ]
+                    ].
         })
             color: (Color gray: 0.92).
         
@@ -22,7 +30,7 @@ public definition = (
             rectangle
                 fill: Color green;
                 frame: 300 height: 300;
-                border: Color yellow width: 3;
+                border: Color yellow width: borderWidth;
                 onClick: [:event | 
                     'onClick' out.
                 ];
@@ -57,7 +65,6 @@ public definition = (
                     'onTouchCancel' out.
                 ].
         })
-            color: (Color gray: 0.5)
     }
 )
 public isKindOfDemoPresenter ^ <Boolean> = (


### PR DESCRIPTION
HopscotchGestureDemo contains the initial work on declarative event handling for:

```
    onClick
    onMouseDown
    onMouseEnter
    onMouseMove
    onMouseOver
    onMouseOut
    onMouseUp
    onTouchStart
    onTouchMove
    onTouchEnd
    onTouchCancel
    onWheel
```

Declaring a rectangle view and adding handlers looks like this:

```
     rectangle
                fill: Color green;
                frame: 300 height: 300;
                border: Color yellow width: 3;
                onClick: [:event | 
                    'onClick' out.
                ];
                onMouseDown: [:event | 
                    'onMouseDown' out.
                ];
                onMouseUp: [:event | 
                    'onMouseUp' out.
                ];
                onMouseEnter: [:event | 
                    'onMouseEnter' out.
                ];
                onMouseMove: [:event | 
                    'onMouseMove' out.
                ];
                onMouseOut: [:event | 
                    'onMouseOut' out.
                ];
                onWheel: [:event | 
                    'onWheel' out.
                ];
                onTouchStart: [:event | 
                    'onTouchStart' out.
                ];
                onTouchMove: [:event | 
                    'onTouchMove' out.
                ];
                onTouchEnd: [:event | 
                    'onTouchEnd' out.
                ];
                onTouchCancel: [:event | 
                    'onTouchCancel' out.
                ].
```
I have started to modify the Hopscotch code to lay a framework for more declarative widgets.

 I'll be adding more assuming this seems like the correct direction to be taking.

