### PR TITLE
Basic radio button

### DIFF
--- a/HopscotchFontDemo.ns
+++ b/HopscotchFontDemo.ns
@@ -106,6 +106,14 @@ public definition = (
                 (label: 'Strikethrough')
                     fontWeight: #thin;
                     strikethrough.
+
+                    mediumBlank.
+
+                radioButton: 'Strikethrough' 
+                    state: underlined 
+                    action: [ :checked | 
+                        checked out.
+                    ].
             }).
 
             mediumBlank.

--- a/HopscotchFontDemo.ns
+++ b/HopscotchFontDemo.ns
@@ -107,10 +107,20 @@ public definition = (
                     fontWeight: #thin;
                     strikethrough.
 
-                    mediumBlank.
+                mediumBlank.
 
-                radioButton: 'Strikethrough' 
-                    state: underlined 
+                radioButton: 'On' 
+                    state: true
+                    group: 'strikethrough'
+                    action: [ :checked | 
+                        checked out.
+                    ].
+
+                mediumBlank.
+
+                radioButton: 'Off' 
+                    state: false
+                    group: 'strikethrough'
                     action: [ :checked | 
                         checked out.
                     ].

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -242,9 +242,14 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 )
 ) : (
 )
-class RadioButtonFragment text: t <String> state: s <Boolean | State> action: a <[:Boolean]> = LeafFragment (
+class RadioButtonFragment 
+	text: t <String> 
+	state: s <Boolean | State> 
+	group: g <Integer> 
+	action: a <[:Boolean]> = LeafFragment (
     |
     text <String> ::= t.
+	group <Integer> = g.
     action <[:Boolean]> = a.
     state <State>
     checked <Boolean>
@@ -2328,8 +2333,8 @@ canvas: extent <Point> = (
 checkbox: text <String> state: s <State> action: a <[:Boolean]> = (
 	^CheckboxFragment text: text state: s action: a
 )
-radioButton: text <String> state: s <State> action: a <[:Boolean]> = (
-	^RadioButtonFragment text: text state: s action: a
+radioButton: text <String> state: s <State> group: g <Integer> action: a <[:Boolean]> = (
+	^RadioButtonFragment text: text state: s group: g action: a
 )
 rectangle = (
 	^RectangleFragment new

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -240,7 +240,79 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
     | oldVisual = oldFragment visual.|
    ^oldVisual
 )
-updateValue = (
+) : (
+)
+class RadioButtonFragment text: t <String> state: s <Boolean | State> action: a <[:Boolean]> = LeafFragment (
+    |
+    text <String> ::= t.
+    action <[:Boolean]> = a.
+    state <State>
+    checked <Boolean>
+    subscription <Block>
+    button <Alien[Element]>
+    |
+
+     s isKindOfState 
+        ifTrue: [
+            state:: s
+            checked:: state getValue.
+            subscription:: state channel => [:value | 
+                checked:: value.
+                button at: 'checked' put: checked.
+            ].
+        ]
+        ifFalse: [
+            checked:: s
+        ].
+) (
+createVisual = (
+    | 
+    container <Alien[Div]> = document createElement: 'div'.
+    label <Alien[Element]> = document createTextNode: text.
+    |
+
+	container at: 'id' put: 'RadioButtonContainer'.
+
+    (container at: 'style')
+        at: 'display' put: 'flex';
+        at: 'flex-direction' put: 'row';
+        at: 'align-items' put: 'center';
+        at: 'justify-content' put: 'flex-start'.
+        
+    button:: document createElement: 'input'. 
+    button
+        at: 'type' put: 'radio';
+        at: 'checked' put: checked;
+        at: 'oninput' put: [:event |    
+            checked:: checked not.
+            state isNil ifFalse: [         
+                state setValue: checked.
+            ].
+            action isNil ifFalse: [
+                action value: checked.
+            ].
+            false
+        ].
+    container appendChild: button.
+
+    container appendChild: label.
+
+    (button at: 'style')
+        at: 'min-width' put: styleCheckInputHeight;
+        at: 'min-height' put: styleCheckInputHeight;
+        at: 'margin-right' put: '5px'.
+
+    ^container.
+)
+public isKindOfRadioButtonFragment ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfRadioButtonFragment
+)
+updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
+    | oldVisual = oldFragment visual.|
+   ^oldVisual
 )
 ) : (
 )
@@ -312,8 +384,6 @@ isMyKind: f <Fragment> ^ <Boolean> = (
 updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
     | oldVisual = oldFragment visual.|
    ^oldVisual
-)
-updateValue = (
 )
 ) : (
 )
@@ -2257,6 +2327,9 @@ canvas: extent <Point> = (
 )
 checkbox: text <String> state: s <State> action: a <[:Boolean]> = (
 	^CheckboxFragment text: text state: s action: a
+)
+radioButton: text <String> state: s <State> action: a <[:Boolean]> = (
+	^RadioButtonFragment text: text state: s action: a
 )
 rectangle = (
 	^RectangleFragment new

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -245,11 +245,11 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 class RadioButtonFragment 
 	text: t <String> 
 	state: s <Boolean | State> 
-	group: g <Integer> 
+	group: g <String> 
 	action: a <[:Boolean]> = LeafFragment (
     |
     text <String> ::= t.
-	group <Integer> = g.
+	group <String> = g.
     action <[:Boolean]> = a.
     state <State>
     checked <Boolean>
@@ -288,6 +288,7 @@ createVisual = (
     button
         at: 'type' put: 'radio';
         at: 'checked' put: checked;
+		at: 'name' put: group;
         at: 'oninput' put: [:event |    
             checked:: checked not.
             state isNil ifFalse: [         


### PR DESCRIPTION
Add suport for a basic radio button. A "group" argument is used to group the buttons into sets, where clicking one, unselects the others.

I'll add suport for label styling at the same time I do checkboxes.

