### PR TITLE
Add date and time picker

### DIFF
--- a/HopscotchFontDemo.ns
+++ b/HopscotchFontDemo.ns
@@ -135,7 +135,7 @@ public definition = (
 
                 mediumBlank.
 
-                colorPicker: '#ff0000' action: [ :value | 
+                colorPicker: '01/29/2021' action: [ :value | 
                     value out.
                 ].
             }).
@@ -166,6 +166,12 @@ public definition = (
             (row: {
                 (label: 'Semibold')
                     fontWeight: #semibold.
+
+                mediumBlank.
+
+                datePicker: '#12345' action: [ :value | 
+                    value out.
+                ].
             }).
 
             mediumBlank.

--- a/HopscotchFontDemo.ns
+++ b/HopscotchFontDemo.ns
@@ -135,7 +135,7 @@ public definition = (
 
                 mediumBlank.
 
-                colorPicker: '#12345' action: [ :value | 
+                colorPicker: '#ff0000' action: [ :value | 
                     value out.
                 ].
             }).

--- a/HopscotchFontDemo.ns
+++ b/HopscotchFontDemo.ns
@@ -135,7 +135,7 @@ public definition = (
 
                 mediumBlank.
 
-                colorPicker: '01/29/2021' action: [ :value | 
+                colorPicker: '#12345' action: [ :value | 
                     value out.
                 ].
             }).
@@ -169,7 +169,7 @@ public definition = (
 
                 mediumBlank.
 
-                datePicker: '#12345' action: [ :value | 
+                datePicker: '1984-01-22' action: [ :value | 
                     value out.
                 ].
             }).
@@ -179,6 +179,12 @@ public definition = (
             (row: {
                 (label: 'Bold')
                     fontWeight: #bold.
+
+                mediumBlank.
+
+                timePicker: '14:00' action: [ :value | 
+                    value out.
+                ].
             }).
 
             mediumBlank.

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -302,6 +302,60 @@ updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
 )
 ) : (
 )
+class DatePickerFragment state: s <String | State> action: a <[:String]> = LeafFragment (
+    |
+    action <[:String]> = a.
+    state <State>
+    date <String>
+    subscription <Block>
+    picker <Alien[Element]>
+    |
+
+     s isKindOfState 
+        ifTrue: [
+            state:: s
+            date:: state getValue.
+            subscription:: state channel => [:value | 
+                date:: value.
+                picker at: 'value' put: date.
+            ].
+        ]
+        ifFalse: [
+            date:: s
+        ].
+) (
+createVisual = (
+        
+    picker:: document createElement: 'input'. 
+    picker
+        at: 'id' put: 'DatePicker';
+        at: 'type' put: 'date';
+        at: 'value' put: date;
+        at: 'oninput' put: [:event |   
+            date:: picker at: 'value'.
+            state isNil ifFalse: [         
+                state setValue: date.
+            ].
+            action isNil ifFalse: [
+                action value: date.
+            ].
+            false
+        ].
+
+    ^picker.
+)
+public isKindOfDatePickerFragment ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfDatePickerFragment
+)
+updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
+    | oldVisual = oldFragment visual.|
+   ^oldVisual
+)
+) : (
+)
 class PickerFragment text: t <String> items: i <List[String]> action: a <[:String]> = LeafFragment (
     |
     text <String> ::= t.
@@ -2467,6 +2521,9 @@ checkbox: text <String> state: s <State> action: a <[:Boolean]> = (
 )
 colorPicker: state <State> action: a <[:Boolean]> = (
 	^ColorPickerFragment state: state action: a
+)
+datePicker: state <State> action: a <[:Boolean]> = (
+	^DatePickerFragment state: state action: a
 )
 picker: text <String> items: i <List[String]> action: a <[:String]> = (
 	^PickerFragment text: text items: i action: a

--- a/HopscotchForHTML5.ns
+++ b/HopscotchForHTML5.ns
@@ -637,6 +637,60 @@ updateVisualsFromSameKind: oldFragment <ButtonFragment>  ^ <Alien[ButtonElement]
 )
 ) : (
 )
+class TimePickerFragment state: s <String | State> action: a <[:String]> = LeafFragment (
+    |
+    action <[:String]> = a.
+    state <State>
+    time <String>
+    subscription <Block>
+    picker <Alien[Element]>
+    |
+
+     s isKindOfState 
+        ifTrue: [
+            state:: s
+            time:: state getValue.
+            subscription:: state channel => [:value | 
+                time:: value.
+                picker at: 'value' put: time.
+            ].
+        ]
+        ifFalse: [
+            time:: s
+        ].
+) (
+createVisual = (
+        
+    picker:: document createElement: 'input'. 
+    picker
+        at: 'id' put: 'TimePicker';
+        at: 'type' put: 'time';
+        at: 'value' put: time;
+        at: 'oninput' put: [:event |   
+            time:: picker at: 'value'.
+            state isNil ifFalse: [         
+                state setValue: time.
+            ].
+            action isNil ifFalse: [
+                action value: time.
+            ].
+            false
+        ].
+
+    ^picker.
+)
+public isKindOfTimePickerFragment ^ <Boolean> = (
+  ^true
+)
+isMyKind: f <Fragment> ^ <Boolean> = (
+  ^f isKindOfTimePickerFragment
+)
+updateVisualsFromSameKind: oldFragment <Fragment> ^ <Alien[Element]> = (
+    | oldVisual = oldFragment visual.|
+   ^oldVisual
+)
+) : (
+)
 class CallBackWrapper wrapping: h <[:T :S]> = (
 |
 	public callback <[:T :S]> ::= h.
@@ -2536,6 +2590,9 @@ rectangle = (
 )
 slider: value <State> min: mn <Float> max: mx <Float> = (
 	^SliderFragment value: value min: mn max: mx
+)
+timePicker: state <State> action: a <[:Boolean]> = (
+	^TimePickerFragment state: state action: a
 )
 public childrenDo: aBlock = (
 	nil = substanceSlot ifFalse: [aBlock value: substanceSlot]


### PR DESCRIPTION
Date and time picker controls. These controls are not fully supported in versions of Safari before 14.1. This probably won't be an issue as updates are typically installed automatically for OS X users. If it does become an issue, there are some fallbacks we could take.