### PR TITLE
TL;DR:   This commit fixes the failure of the Newspeak service worker (sw.js) to update its caches.  See description for (much more) details.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,20 @@ pushd ../primordialsoup
 ./build os=emscripten arch=wasm
 popd
 
+# Back in 'newspeak'.
+# Increase the pwaVersion in the PWA service worker, the newspeak/platforms/webIDE/sw.js
+# This is required on every Newspeak build (strictly speaking,
+#   only on every Newspeak deployment to HTTP server), for the PWA clients
+#   to refresh all caches.
+# Without the pwaVersion increase, PWA clients would not replace
+#   the cached HopscotchWebIDE.vfuel with the new version,
+#   unless forced by manual cache clean or similar
+
+. ./increase-pwa-version.sh
+
+# Ensure the newspeak/out directory exists, and copy into it:
+#   - The primordialsoup built primordialsoup.html, primordialsoup.js, primordialsoup.wasm
+#   - All primordialsoup built snapshots of vfuel files such as WebCompiler.vfuel
 mkdir -p out
 cp ../primordialsoup/out/ReleaseEmscriptenWASM/primordialsoup.* out
 cp ../primordialsoup/out/snapshots/*.vfuel out

--- a/increase-pwa-version.sh
+++ b/increase-pwa-version.sh
@@ -1,0 +1,37 @@
+#
+# Replaces the version line in service worked JS file sw.js
+# This could be a one-liner if we could assume GNU tools are installed.
+#
+
+SW_FILE=platforms/webIDE/sw.js
+
+if [ ! -f ${SW_FILE} ]; then
+    echo Service worker file does not exist, returning
+    # Note: only can do this if this is sourced!
+    return
+fi
+
+# Pull the version number from code. Assumes a fixed syntax for it.
+PWA_VERSION=$(sed -E -n "s/^const pwaVersion = ([0-9]+);$/\1/p" ${SW_FILE})
+
+# Increase the version number
+PWA_VERSION=$((${PWA_VERSION} + 1))
+
+# If backup file exists, store it under a different name, just in case
+if [ -f ${SW_FILE}.bu ]; then echo Moving an old backup, just in case ...; mv ${SW_FILE}.bu ${SW_FILE}.bu.old; fi
+
+# Replace the version number in code for the increased version.
+sed -E -i.bu "s/^const pwaVersion = ([0-9]+);$/const pwaVersion = ${PWA_VERSION};/" ${SW_FILE}
+
+# Lazy check the substitution did not trash the file - must differ by max 1 char. If not, go to .bu
+SIZE_DIFF=$(( $(wc ${SW_FILE} | awk '{print $3}') - $(wc ${SW_FILE}.bu | awk '{print $3}') )) 
+if [ ${SIZE_DIFF} -gt 1 -o ${SIZE_DIFF} -lt 0 ]; then
+    echo ERROR sed likely failed to substitute, going back to backup. SIZE_DIFF=$SIZE_DIFF  
+    mv ${SW_FILE}.bu ${SW_FILE}
+else
+    echo
+    echo increase-pwa-version.sh : Success: Increased the PWA version in ${SW_FILE} to pwaVersion=${PWA_VERSION}. SIZE_DIFF=$SIZE_DIFF
+    echo increase-pwa-version.sh : Removing the backup file ${SW_FILE}.bu
+    echo
+    rm ${SW_FILE}.bu
+fi

--- a/platforms/webIDE/index.html
+++ b/platforms/webIDE/index.html
@@ -41,9 +41,10 @@
         '/webIDE/public/assets/lib/codemirror.js',
         '/webIDE/public/assets/lib/codemirror_autorefresh.js',
         '/webIDE/public/assets/lib/jszip.min.js',
-
       ];
 
+      // Dynamic scripts with async=false all load, then execute in listed order
+      // (like defer), just before DOMContentLoaded.
       scripts.forEach(function (url) {
         let script = document.createElement('script');
         script.src = url;
@@ -51,24 +52,18 @@
         document.body.appendChild(script);
       });
 
-      const otherAssets = {
-        codemirror_css: '/webIDE/public/assets/lib/codemirror.css',
-        primordialsoup_wasm: '/webIDE/public/assets/lib/primordialsoup.wasm',
-        hopscotch_vfuel: '/webIDE/public/assets/lib/HopscotchWebIDE.vfuel',
-      };
-
-      // Cache-able URLs
-      const cacheUrls = scripts.concat('/', Object.values(otherAssets));
-
-      (async () => {
-        const cacheAvailable = 'caches' in self;
-
-        const cache = await caches.open('newspeak-ide-cache');
-        cache.addAll(cacheUrls);
-      })();
-
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/webIDE/sw.js');
+        // Register service worker. Default scope starts at /webIDE/.
+        navigator.serviceWorker.register('/webIDE/sw.js').then(
+          (registration) => {
+            console.log('Service worker registration success: ' + registration);
+          },
+          (error) => {
+            console.error('Service worker registration failed: ' + error);
+          }
+        );
+      } else {
+        console.error('Browser does not support service workers!');
       }
     </script>
   </body>

--- a/platforms/webIDE/sw.js
+++ b/platforms/webIDE/sw.js
@@ -1,24 +1,300 @@
-const cacheName = 'newspeak-ide-cache'
-// Installing Service Worker
-self.addEventListener('install', (e) => {
-    console.log('[Service Worker] Install');
-    // e.waitUntil((async () => {
-    //   const cache = await caches.open(cacheName);
-    //   console.log('[Service Worker] Caching all: app shell and content');
-    //   await cache.addAll(contentToCache);
-    // })());
-  });
+// Service worker lifecycle - summary
+// 
+//    - From https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers:
+//      - Once the PWA is installed on the user's machine, THE ONLY WAY to inform
+//        the browser that there are updated files to be retrieved is to change
+//        the service worker (this file, sw.js) on the server.
+// 
+//    - Corollary: The only way for a PWA website to force an update of the service worker
+//        is to make a bit-change on the server's service worker (the sw.js).
+// 
+//        Such enforced update of the service worker, causes the browser to call
+//        one-time 'install' and 'activate' on the service worker, which the service worker
+//        can use to delete old caches and cache the new assets.
+//
+// Service worker lifecycle - processing in Newspeak
+//
+//   - The modified service worker sw.js is partly based on the link in the summary section above.
+//   - The Newspeak web page index.html's calls navigator.register on this script,
+//     the sw.js (the service worker).
+//   - During the above registration, this sw.js file is compared to the server version.
+//   - ONLY if the server sw.js changes:
+//       the PWA starts to install the new server version sw.js to the local PWA;
+//       this local install is done by trigerring listeners registered
+//       on the 'install' and 'activate' events on the
+//       local running sw.js. We use the 'activate' event to update the local PWA caches.
+//     else:
+//       only further lifecycle events such as 'fetch' are trigerred on the sw.js.
+//
+// Sources:
+//
+//   - https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers
+//   - https://web.dev/articles/service-worker-lifecycle
+//   - https://stackoverflow.com/questions/49739438/when-and-how-does-a-pwa-update-itself
+// 
+// Goals:
+//
+//  - During the PWA update of the Newspeak webIDE, we generally want to update
+//    the cached resources.
+//  - Also (I assume) we want to keep the cache-first strategy of looking up
+//    resources, currently implemented in the 'fetch' event.
+//    I assume cache-first is used for simplicity and savind the server resources.
+//
+// Goals implementation:
+//
+//  - Any time we want to force the PWA to update caches, we change some bits
+//    on the server's sw.js.
+//  - The changed bits happen to be a 'version number',
+//    which we also use to version the cache, and to delete the old cache versions.
+//  - The bits change will cause the PWA to 'install' and 'activate' the new sw.js,
+//    by trigerring the 'install' and 'activate' events on the listeners which the sw.js registered.
+//    The 'install' event is trigerred only once ever, when the server's sw.js is changed.
+//  - After 'install', the 'activate' event is trigerred.
+//  - We use the 'version' number to version caches, and we use the 'activate'
+//    event listener to delete old caches.
 
-  // Fetching content using Service Worker
-self.addEventListener('fetch', (e) => {
-    e.respondWith((async () => {
-      const r = await caches.match(e.request);
-      console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
-      if (r) return r;
-      const response = await fetch(e.request);
-      const cache = await caches.open(cacheName);
-      console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
-      cache.put(e.request, response.clone());
-      return response;
-    })());
-  });
+//
+// The version of the cache in the 'caches' global variable.
+// 
+// The version should be updated (increased) every time the server wants to force
+// the client PWAs to update. Any change in the service worker
+// causes the browser to activate the new service worker, which in turn,
+// updates the caches, by using a new name for the cache, and deleting
+// the old cache in the 'activate' event listener (code also added in this commit).
+// 
+// The version update can be done either manually (we rely on this),
+// or by applying some framework that generates this sw.js worker script.
+
+const pwaVersion = 13;
+
+// Cache name used by the 'caches' global variable.
+// The pwaCacheName now includes the pwaVersion;
+// old pwaVersion of cache is deleted in the 'activate' event listener.
+
+const pwaCacheName = 'newspeak-ide-cache-version-' + pwaVersion;
+
+// Resources cached initially
+
+const pwaAppResources = [
+    '/',
+    // '/index.html', // consider adding, but '/' fetches index.html as well
+    
+    '/webIDE/public/assets/lib/primordialsoup-setup.js',
+    '/webIDE/public/assets/lib/primordialsoup.js',
+    '/webIDE/public/assets/lib/codemirror.js',
+    '/webIDE/public/assets/lib/codemirror_autorefresh.js',
+    '/webIDE/public/assets/lib/jszip.min.js',
+    
+    '/webIDE/public/assets/lib/codemirror.css',
+    '/webIDE/public/assets/lib/primordialsoup.wasm',
+    '/webIDE/public/assets/lib/HopscotchWebIDE.vfuel',
+
+    // Top level images
+    // The vfuel images aliens generate requests from top level - not right, but currently so.
+    // Luckily, requests for images on top level are not outside of service worker scope,
+    // as the scope looks at the source of the request - which is below /webIDE/, so in scope.
+    
+    '/accept16px.png',
+    '/ampleforthDocument.png',
+    '/cancel16px.png',
+    '/classPresenterImage.png',
+    '/classUnknownImage.png',
+    '/clearImage.png',
+    '/disclosureClosedImage.png',
+    '/disclosureOpenImage.png',
+    '/downloadImage.png',
+    '/findImage.png',
+    '/helpImage.png',
+    '/hsAddImage.png',
+    '/hsBackImage.png',
+    '/hsCollapseImage.png',
+    '/hsDropdownImage.png',
+    '/hsExpandImage.png',
+    '/hsForwardImage.png',
+    '/hsHistoryImage.png',
+    '/hsHomeImage.png',
+    '/hsNewImage.png',
+    '/hsRefreshImage.png',
+    '/itemReferencesImage.png',
+    '/languageNewspeak3.png',
+    '/peekingeye1610.png',
+    '/privateImage.png',
+    '/protectedImage.png',
+    '/publicImage.png',
+    '/saveImage.png',
+];
+
+// Add all resources to cache.
+// Intended to be called in 'initialize' for pwaAppResources.
+
+const addAllResourcesToCache = async (resources, cacheName) => {
+    const cache = await caches.open(cacheName);
+    // Cache.addAll() takes an array of URLs, makes a request and fetches
+    // the response for each, then adds each request/response to the cache.
+    await cache.addAll(resources);
+};
+
+// Cache the request / response in cache named cacheName.
+// The response must be cloned from fetch, cacheName should be pwaCacheName.
+// Intended to be called in 'fetch' for assets fetched from network
+//   (when request.url is not in pwaAppResources)
+
+const putInCache = async (request, response, cacheName) => {
+    const cache = await caches.open(cacheName);
+    await cache.put(request, response);
+};
+
+// Find match for the passed request in the passed cacheName, obtaining response.
+// If no such request is cached, returns undefined.
+// Intended to be called in 'fetch' to get response of cached request/response.
+
+const getMatchingCachedResponseFor = async (request, cacheName) => {
+    const cache = await caches.open(cacheName);
+    const cachedResponse = await cache.match(request.url);
+    return cachedResponse;
+};
+
+// Fetch the url in the passed request, looking into cache first.
+// If the request url is not in cache, go to network, and cache the result
+
+// Fetch the url in the passed request using cache-first strategy:
+//   Cache-match the cached response with the request url and return it if exists.
+//   If no matching cached response exists, go to network,
+//     cache the response, and return it.
+//   Catch exception of both cache and network failure,
+//     return 408 response or fetchErrorUrl.
+
+const fetchCacheFirst = async({ request, cacheName, fetchErrorUrl }) => {
+    
+    const cachedResponse = await getMatchingCachedResponseFor(request, cacheName);
+    
+    // If response exists in cache, return it.
+    if (cachedResponse !== undefined) {
+        return cachedResponse;
+    }
+            
+    // To support requesting resources not cached during 'install',
+    // go to network, cache and return the network response.
+    
+    try {
+        const url = request.url;                
+        console.log(`[ServiceWorker:fetch:fetchCacheFirst] caching resource from net: ${url}`);
+        
+        const networkResponse = await fetch(request);
+        
+        // Response may be used only once, unless cloned.
+        // So put networkResponse clone to cache for future multi-use,
+        // and return the networkResponse for current use.
+        putInCache(request, networkResponse.clone(), cacheName);
+        
+        return networkResponse;
+        
+    } catch (error) {
+        const errorText = `Error fetching url=${url} from site.`;
+        console.error(errorText);
+        // could get error image from cache: return caches.match(fetchErrorUrl);
+        return new Response(errorText, {
+            status: 408,
+            headers: { 'Content-Type': 'text/plain' },
+        });
+    }
+};
+
+// Add listener to service worker for service worker receiving the 'install' event.
+// This event is emitted (and the listener called) when a new service worker
+// is being installed.
+// The event.waitUntil waits and keeps the new service worker
+// in the 'installing' phase until the tasks here complete - that is,
+// the install waits until all pwaAppResources are added to cache.
+
+self.addEventListener('install', (event) => {
+    console.log('[ServiceWorker:install:start]');
+    // Skip waiting causes 'activate' (does old cache delete) to be called immediately after 'install'.
+    // See https://web.dev/articles/service-worker-lifecycle#skip_the_waiting_phase
+    self.skipWaiting();
+
+    // wait until the callback is done (addAllResourcesToCache)
+    event.waitUntil(
+        (async () => {
+            console.log('[ServiceWorker:install:event.waitUntil->callback:start] Caching all static resources.');
+            // Async add all pwaAppResources to pwaCache
+            addAllResourcesToCache(pwaAppResources, pwaCacheName);
+            console.log('[ServiceWorker:install:event.waitUntil->callback:end] Caching all static resources.');
+        })()
+    );
+});
+
+// Add listener to service worker for service worker receiving the 'activate' event.
+// The listener deletes old caches..
+//
+// Note: After update, on first start of the PWA, if we did NOT call skipWaiting,
+//       we would see both old and new cache in debuggers.
+//       However, the PWA would still correctly use the old cache in 'fetch'es!
+//       See https://web.dev/articles/service-worker-lifecycle:
+//
+
+self.addEventListener('activate', (event) => {
+    console.log('[ServiceWorker:activate:start]');
+    event.waitUntil(
+        (async () => {
+            console.log('[ServiceWorker:activate:event.waitUntil->callback] Deleting old caches.');
+            const names = await caches.keys();
+            // Promise.all() takes list of promises and returns a single Promise
+            // which 'then' method resolves all promises in list before resolving self.
+            await Promise.all(
+                // All caches that belong to this service worker,
+                // except the current (pwaVersion) cache, delete.
+                names.map((name) => {
+                    if (name !== pwaCacheName) {
+                        return caches.delete(name);
+                    } else {
+                        return false;
+                    }
+                }),
+            );
+            // Set itself (pw.js) as controller of the "client" = running PWA instance.
+            // This way, clients loaded in same scope do not need reload (todo probably not needed)
+            await clients.claim();
+        })(),
+    );
+});
+
+// Add listener to service worker for service worker receiving the 'fetch' event.
+// The FetchEvent is emitted by the browser to this service worker
+// when it intercepts all fetches, and gives this service worker a chance
+// to handle each fetch request in this listener.
+//
+// This listener registers a callback named 'fetchCacheFirst' with the event
+// by calling event.respondWith(fetchCacheFirst).
+// The callback returns a response for the request wrapped in event.request
+// looking first in cache, then to the network.
+
+self.addEventListener('fetch', (event) => {
+    
+    console.log('[ServiceWorker:fetch:start] url=' + event.request.url);
+
+    // Only capture and cache http/https requests
+    if (!event.request.url.match('^(http|https)://')) {
+        console.log(`[ServiceWorker:fetch:match http] by design, refusing to cache URL with scheme ${event.request.url}.`);
+        return;
+    }
+
+    /* 
+    if (event.request.mode === 'navigate') {
+        // Newspeak single page app, when navigating (fetching HTML page)
+        // should return directly to the (cached) index.html page
+        event.respondWith(caches.match('/'));
+        return;
+    }
+    */
+
+    // For all other requests, look for response to cache first,
+    // then to network, and return the response.
+    event.respondWith(
+        fetchCacheFirst({
+            request: event.request,
+            cacheName: pwaCacheName,
+            fetchErrorUrl: '/peekingeye1610.png',
+        })
+    );
+});


### PR DESCRIPTION
  - This commit fixes the failure of the Newspeak service worker (sw.js) to update its caches. This issue caused the Newspeak PWA client app on the user's device to never pick up server updates, notably the changed HopscotchWebIDE.vfuel.
  - The changed files are sw.js, index.html, build.sh; there is a new script 'increase-pwa-version.sh' called from 'build.sh'.
  - Apart from fixing the end-user experience, this change also touches Newspeak development (without any changes in the developer's workflow), as running '. ./build.sh' now changes the variable pwaVersion in 'sw.js'
  - How to test this change:
    - Server / build - Get the latest version and make sure webIDE/index.html is copied to the webIDE directory where Newspeak is served locally for https://localhost:8080/webIDE, or for https://newspeaklanguage.org/webIDE. I am serving from the git version of webIDE, so I do not have to copy anything. - Run . ./build.sh as normally. - Make sure the updated webIDE/sw.js is copied into the webIDE directory where Newspeak is served. I am serving from the git version of webIDE, so I do not have to copy anything.

    - PWA Client / browser
      - You do NOT have to do anything, the versioned sw.js should now be installed, and use its versioned cache. But if you want to check: - In Browser, navigate to  https://localhost:8080/webIDE, or https://newspeaklanguage.org/webIDE. - Open the PWA - In both browser and PWA, if you press F12 to debug (Chrome) and look at: Application -> Storage -> Cache Storage. you should see a versioned cache number, such as 'newspeak-ide-cache-version-13'.
      - Every time a new server version is build and the new build deployed, you should see a new cache version on the client PWA or browser, such as 'newspeak-ide-cache-version-14'.

Motivation for change:

  - 'Before this change': After a new Newspeak version deployment on https://newspeaklanguage.org/webIDE, the PWA client app on the user's device did not update even after multiple launches, unless a manual cache clean was performed. I had the same experience (the PWA client not updating) with the webIDE server running on localhost, and the PWA client created from it. In fact, even the in-browser running webIDE did not update after server deployment.

  - Having looked into how service workers function, it seems clear that the mechanism that causes the service worker update on the user's device (changing some bits) was never triggered.  As a result, the service worker caches are never automatically updated, causing, among other things, the same (old) HopscotchWebIDE.vfuel to be used after server update.

Service worker lifecycle - summary

  - From https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers: - Once the PWA is installed on the user's machine, THE ONLY WAY to inform the browser that there are updated files to be retrieved is to change the service worker (this file, sw.js) on the server.

  - Corollary: The only way for a PWA website to force an update of the service worker is to make a bit-change on the server's service worker (the sw.js).

      Such enforced update of the service worker, causes the browser to call a one-time 'install' and 'activate' on the
      service worker, which the service worker can use to delete old caches and cache the new assets.

Changes in more detail:

  - index.html - moved caching of assets (cache.addAll) to the 'install' event in sw.js - added catching errors during serviceWorker.register
  - sw.js
    - almost complete rewrite, although keeping the basics of using cache-first strategy (assuming used to lighten load on the server)
    - added a version number which should be changed on every deployment, to support the reinstall of the service worker on the client PWA browser. This number is increased automatically, during running each '. ./build.sh' by calling the added 'increase-pwa-version.sh'
      - 'const pwaVersion = 12;' - added a versioned cache name
      - 'const pwaCacheName = 'newspeak-ide-cache-version-' + pwaVersion;' - added a full list of assets - 'const pwaAppResources = [ .. see code .. ];' - added processing in the 'install' event: - all assets listed in 'pwaAppResources' are added to the NEW cache version 'pwaCacheName' - added processing in the 'activate' event: - OLD caches are deleted - modified processing in the 'fetch' event - In principle, this remains the cache-first fetching, but error checking was added etc - Assets not in 'pwaAppResources' would still cache here from network
  - build.sh - added call to 'increase-pwa-version.sh' which increases version number in sw.js by 1, example - 'const pwaVersion = 12;' => 'const pwaVersion = 13;'
  - increase-pwa-version.sh
    - a simple sed script that edits sw.js and increases version number by 1.