### PR TITLE
Changed PWA from minimal-ui to standalone, added Help for back/forward navigation in PWA, removed "I think" from comments

### DIFF
--- a/Browsing.ns
+++ b/Browsing.ns
@@ -4802,14 +4802,26 @@ helpText = (
   ^ampleforth: 'At the top right of the IDE window you find:
   <br>
   <ul>
-  <li><div class="hopscotchHistoryButton"> </div>The history button shows you a list of all the presenters visited in the current session.</li>
+  <li><div class="hopscotchHistoryButton"> </div>The history button shows you a list of all the presenters (''pages'') visited in the current session.  Alternatively, to navigate back and forth between visited presenters, you can use the viewer specific controls - see the ''Navigation'' section below.</li>
   <li><div class="hopscotchHomeButton"> </div>The home button takes you to the home page.</li>  
   <li><div class="hopscotchRefreshButton"> </div> Refreshes the display. The same icon is used for refreshing individual presenters everywhere in the system.</li> 
   <li><div class="hopscotchHelpButton"> </div> Shows this help message. This icon is used by presenters throughout the system to show help.</li>    
   <li><div class="hopscotchSaveAllButton"> </div> Saves the current IDE contents to a file. <b>Beware! The button in the help is live!</b></li> 
   <li><div class="hopscotchSearchBar"> </div> The search bar allow you to search for classes, methods and namespaces defined in the system. You can use wildcards in search terms. Pressing return or clicking on the search icon (<img src=''', findImage, ''' alt="" width="18" height="30">) triggers the search.</li>  
   </ul>
-  If you are running in the web browser, use the browser''s navigation controls to go back and forth between presenters. If you are running locally, you''ll find arrows at the top right. These will work very much like in a  web browser.
+  <p><bold>Navigation</bold></p>
+  Back and forth navigation between presenters (''pages'') differs depending on the viever:
+  <ul>
+    <li>In the web browser, use the browser''s navigation back and forward controls.</li>
+    <li>In the Progressive Web App (PWA), use the standard keyboard shortcuts.
+      <ul>
+        <li>In Chrome or Chromium on Linux and Windows: To navigate back, use Alt + left arrow. To navigate forward, use Alt + right arrow.</li>
+        <li>In Chrome or Chromium on the Mac: To navigate back, use MacCmd + left arrow. To navigate forward, use MacCmd + right arrow.</li>
+      </ul>
+    </li>
+    <li>In Electron, you''ll find arrows at the top right. These will work very much like in a web browser.</li>
+  </ul>
+
   <br><br>
       You can close the help section by pressing <div class = "hopscotchCloseHelpButton"></div>, a convention is used in all help sections.
   '

--- a/Browsing.ns
+++ b/Browsing.ns
@@ -4809,14 +4809,14 @@ helpText = (
   <li><div class="hopscotchSaveAllButton"> </div> Saves the current IDE contents to a file. <b>Beware! The button in the help is live!</b></li> 
   <li><div class="hopscotchSearchBar"> </div> The search bar allow you to search for classes, methods and namespaces defined in the system. You can use wildcards in search terms. Pressing return or clicking on the search icon (<img src=''', findImage, ''' alt="" width="18" height="30">) triggers the search.</li>  
   </ul>
-  <p><bold>Navigation</bold></p>
+  <p><strong>Navigation</strong></p>
   Back and forth navigation between presenters (''pages'') differs depending on the viever:
   <ul>
     <li>In the web browser, use the browser''s navigation back and forward controls.</li>
     <li>In the Progressive Web App (PWA), use the standard keyboard shortcuts.
       <ul>
-        <li>In Chrome or Chromium on Linux and Windows: To navigate back, use Alt + left arrow. To navigate forward, use Alt + right arrow.</li>
-        <li>In Chrome or Chromium on the Mac: To navigate back, use MacCmd + left arrow. To navigate forward, use MacCmd + right arrow.</li>
+        <li>In Chrome and Chromium on Linux and Windows: To navigate back, use Alt + left arrow. To navigate forward, use Alt + right arrow.</li>
+        <li>In Chrome and Chromium on Mac and iOS: To navigate back, use MacCmd + left arrow. To navigate forward, use MacCmd + right arrow.</li>
       </ul>
     </li>
     <li>In Electron, you''ll find arrows at the top right. These will work very much like in a web browser.</li>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The installation steps:
 You can use the following commands to execute 1. and 2. just above:
 
 ```sh
-mkdir ~/software/nswasm
+mkdir --parent ~/software/nswasm
 cd ~/software/nswasm # Adjust to your directory path
 git clone https://github.com/newspeaklanguage/newspeak.git
 git clone https://github.com/newspeaklanguage/primordialsoup.git
@@ -282,7 +282,7 @@ cd tool
 #
 #   3. Deploy files to server running from
 #      the '../out' directory, serving as 'localhost'. 
-#      This mimicks (I think) how the server ran before this change.
+#      This mimicks how the server was originally used, serving from the '../out' directory.
 #      The advantage of serving from the '../out' directory is that 
 #      *you ONLY need to run the 'deploy' script once, after, just keep running the 'build.sh' script.*
 #      - cd tool
@@ -350,7 +350,7 @@ cd tool
 #     - ./deploy-all-vfuels-as-website.sh  ~/servers/newspeak-http-server
 #   2. Deploy files to server running from
 #      the '../out' directory.
-#      This mimicks (I think) how the server ran before this change 
+#      This mimicks how the server was originally used, serving from the '../out' directory.
 #      The advantage of serving from the '../out' directory is that 
 #      *You ONLY need to run this 'deploy' script once, after, just keep running the 'build.sh' script.*
 #     - cd tool

--- a/platforms/webIDE/manifest.json
+++ b/platforms/webIDE/manifest.json
@@ -2,7 +2,7 @@
   "id": "NewspeakIDE",
   "scope": "/",
   "name": "Newspeak IDE",
-    "display": "minimal-ui",
+  "display": "standalone",
   "start_url": "/webIDE/",
   "short_name": "newspeak-ide",
   "theme_color": "blue",

--- a/tool/deploy-all-vfuels-as-website.sh
+++ b/tool/deploy-all-vfuels-as-website.sh
@@ -45,7 +45,7 @@
 #     - ./deploy-all-vfuels-as-website.sh  ~/servers/newspeak-http-server
 #   2. Deploy files to server running from
 #      the '../out' directory.
-#      This mimicks (I think) how the server ran before this change.
+#      This mimicks how the server was originally used, serving from the '../out' directory.
 #      The advantage of serving from the '../out' directory is that 
 #      *you ONLY need to run this 'deploy' script once, after, just keep running the 'build.sh' script.*
 #     - cd tool

--- a/tool/deploy-webide-vfuel-as-pwa.sh
+++ b/tool/deploy-webide-vfuel-as-pwa.sh
@@ -56,7 +56,7 @@
 #
 #   3. Deploy files to server running from
 #      the '../out' directory, serving as 'localhost'.
-#      This mimicks (I think) how the server ran before this change.
+#      This mimicks how the server was originally used, serving from the '../out' directory.
 #      The advantage of serving from the '../out' directory is that 
 #      *you ONLY need to run this 'deploy' script once, after, just keep running the 'build.sh' script.*
 #      - cd tool


### PR DESCRIPTION
Changed PWA manifest from minimal-ui to standalone, to hide the explicit page navigation controls (because they only show refresh and back, not forward). Added help section (? button on top) explaining how navigation works in browser, PWA and Electron.  Removed the "I think" fro README.md and comments in deployment scripts.